### PR TITLE
Add `on_conflict` options to `copy`, `rename` and `move` actions

### DIFF
--- a/organize/actions/copy.py
+++ b/organize/actions/copy.py
@@ -10,6 +10,9 @@ from .trash import Trash
 logger = logging.getLogger(__name__)
 
 
+CONFLICT_OPTIONS = ("rename_new", "rename_old", "skip", "overwrite")
+
+
 class Copy(Action):
 
     """
@@ -81,9 +84,15 @@ class Copy(Action):
                       counter_separator: '_'
     """
 
-    def __init__(self, dest: str, overwrite=False, counter_separator=" ") -> None:
+    def __init__(
+        self, dest: str, on_conflict="rename_new", counter_separator=" "
+    ) -> None:
+        if on_conflict not in CONFLICT_OPTIONS:
+            raise ValueError(
+                "on_conflict must be one of %s" % ", ".join(CONFLICT_OPTIONS)
+            )
         self.dest = dest
-        self.overwrite = overwrite
+        self.on_conflict = on_conflict
         self.counter_separator = counter_separator
 
     def pipeline(self, args: Mapping) -> None:


### PR DESCRIPTION
The boolean flag `overwrite` in these actions is not sufficient.
Possible options in case of a naming conflict should be:

- `skip` - skip the action for this file
- `overwrite` - run this action and overwrite conflicting files
- `rename_new` - run this action but use a different name for the new file
- `rename_old` - run this action but use a different name for the old file

Additionally a `rename_template` should be implemented in place of the `counter_separator` to allow for more flexible renaming logic.

Feature requested in issue #54.