### PR TITLE
Update DOCS_URL cli.py. Fixes #164

### DIFF
--- a/organize/cli.py
+++ b/organize/cli.py
@@ -14,7 +14,7 @@ from . import console
 from .__version__ import __version__
 from .migration import NeedsMigrationError
 
-DOCS_URL = "https://tfeldmann.github.io/organize/"  # "https://organize.readthedocs.io"
+DOCS_URL = "https://organize.readthedocs.io"  # "https://tfeldmann.github.io/organize/"
 MIGRATE_URL = DOCS_URL + "updating-from-v1/"
 DEFAULT_CONFIG = """\
 # organize configuration file


### PR DESCRIPTION
Updated the DOCS_URL to point to https://organize.readthedocs.io instead of https://tfeldmann.github.io/organize/
