### PR TITLE
'min_depth' added to location options

### DIFF
--- a/organize/config.py
+++ b/organize/config.py
@@ -32,6 +32,7 @@ CONFIG_SCHEMA = Schema(
                             {
                                 "path": And(str, len),
                                 Optional("max_depth"): Or(int, None),
+                                Optional("min_depth"): Or(int, None),
                                 Optional("search"): Or("depth", "breadth"),
                                 Optional("exclude_files"): Or(str, [str]),
                                 Optional("exclude_dirs"): Or(str, [str]),

--- a/tests/actions/test_copy.py
+++ b/tests/actions/test_copy.py
@@ -13,8 +13,37 @@ files = {
         "folder": {
             "x.txt": "",
         },
-    }
+    },
+    "min": {},
+    "max": {},
 }
+
+def test_depth_options():
+    with fs.open_fs("mem://") as mem:
+        config = {
+            "rules": [{
+                "locations": [
+                    {"path": "files", "filesystem": mem, "min_depth": 1},
+                ],
+                "actions": [
+                    {"copy": {"dest": "min/", "filesystem": mem}},
+                ],
+                "subfolders": True
+            },{
+                "locations": [
+                    {"path": "files", "filesystem": mem, "max_depth": 1},
+                ],
+                "actions": [
+                    {"copy": {"dest": "max/", "filesystem": mem}},
+                ],
+                "subfolders": True
+            }]
+        }
+        make_files(mem, files)
+        core.run(config, simulate=False)
+        result = read_files(mem)
+        assert len(result["min"].keys()) == 1
+        assert len(result["max"].keys()) == 3
 
 
 def test_copy_on_itself():


### PR DESCRIPTION
Added a `min_depth` option to location rules to allow for use cases where the user may want to skip applying the rule to lower level paths. For example:

```
root
  |-- folder_1
  |     |-- file_1_a
  |-- folder_2
  |     |-- folder_2_a
  |     |     |-- file_2_a_i
  |-- folder_3
  |     |-- file_3_a
```

Suppose you wanted to move only files at depth 2 and higher up to the parent directory but not affect those at depth 0 or 1. In the above example, you may want to move file `file_2_a_i` to `folder_2` but not affect `file_3_a` or `file_1_a`. Without the min_depth option, you would need to either specify each of the directories to exclude, or run `organize` against `folder_1`, `folder_2` and `folder_3` separately. With the new option, you can just run it against root, then specify `min_depth = 2`.