### PR TITLE
Add overwrite_smaller move conflict option

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -260,6 +260,22 @@ rules:
           on_conflict: "overwrite"
 ```
 
+Use a placeholder to move all .pdf files into a "PDF" folder and all .jpg files into a
+"JPG" folder. Existing files will be overwritten only if they are larger than the existing file.
+
+```yaml
+rules:
+  - locations: ~/Desktop
+    filters:
+      - extension:
+          - pdf
+          - jpg
+    actions:
+      - move:
+          dest: "~/Desktop/{extension.upper()}/"
+          on_conflict: "overwrite_smaller"
+```
+
 Move pdfs into the folder `Invoices`. Keep the filename but do not overwrite existing files. To prevent overwriting files, an index is added to the filename, so `somefile.jpg` becomes `somefile 2.jpg`.
 
 ```yaml

--- a/organize/actions/_conflict_resolution.py
+++ b/organize/actions/_conflict_resolution.py
@@ -15,6 +15,7 @@ from .trash import Trash
 CONFLICT_OPTIONS = (
     "skip",
     "overwrite",
+    "overwrite_smaller",
     "trash",
     "rename_new",
     "rename_existing",
@@ -97,6 +98,21 @@ def resolve_overwrite_conflict(
             elif dst_fs.isfile(dst_path):
                 dst_fs.remove(dst_path)
         return dst_path
+
+    elif conflict_mode == "overwrite_smaller":
+        print(f"Overwrite Smaller {safe_description(dst_fs, dst_path)}.")
+        src_file_larger = src_fs.getsize(src_path) > dst_fs.getsize(dst_path)
+        if not simulate:
+            if dst_fs.isdir(dst_path):
+                dst_fs.removedir(dst_path)
+            elif dst_fs.isfile(dst_path):
+                if src_file_larger:
+                    dst_fs.remove(dst_path)
+        if src_file_larger:
+            return dst_path
+        else:
+            print("Skipped.")
+            return None
 
     elif conflict_mode == "rename_new":
         stem, ext = splitext(dst_path)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

This option overwrites the destination file path with the source file path if the source is larger than the destination.

## Checklist

- [x] Tests for the changes exist and pass on CI
- [x] Documentation reflects the changes where applicable
- [x] Change is documented in CHANGELOG.md (if applicable)
- [x] My PR is ready to review
