### PR TITLE
fix unsuccess strp

### DIFF
--- a/organize/filters/exif.py
+++ b/organize/filters/exif.py
@@ -36,10 +36,10 @@ def to_datetime(key: str, value: str) -> ExifValue:
         converted_value: ExifValue = value
         if "datetime" in key:
             # value = "YYYY:MM:DD HH:MM:SS" --> convert to 'datetime.datetime'
-            converted_value = datetime.strptime(value, "%Y:%m:%d %H:%M:%S")
+            converted_value = datetime.strptime(value[:19], "%Y:%m:%d %H:%M:%S")
         elif "date" in key:
             # value = "YYYY:MM:DD" --> convert to datetime.date
-            converted_value = datetime.strptime(value, "%Y:%m:%d").date()
+            converted_value = datetime.strptime(value[:10], "%Y:%m:%d").date()
         elif "offsettime" in key:
             # value = "+HHMM" or "+HH:MM[:SS]" or "UTC+HH:MM[:SS]"
             # --> convert to 'datetime.timedelta'


### PR DESCRIPTION
Some phones, especially Huawei and Honer, may write `exif.datetimeorigin` as `2018:10:10 14:15:38下午`.

Cut the `datetime` string to only the part needed.

<!-- Thank you for your contribution! -->

## Change Summary

Cut the datetime string to the first chars

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

I haven't raise a issue yet. solved pretty quickly.

## Checklist

- [x] Tests for the changes exist and pass on CI
- [x] Documentation reflects the changes where applicable
- [ ] Change is documented in CHANGELOG.md (if applicable)
- [x] My PR is ready to review
