### PR TITLE
Create parent directory on organize new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fix bug on first run of `organize new`. Create the organize config directory if it does not exist.
+
 ## v3.0.0a1 (2024-01-01)
 
 - Default to UTF-8 encoding when reading and writing config files for windows users

--- a/organize/cli.py
+++ b/organize/cli.py
@@ -112,6 +112,7 @@ def new(config: Optional[str]) -> None:
         )
     except ConfigNotFound as e:
         assert e.init_path is not None
+        e.init_path.parent.mkdir(parents=True, exist_ok=True)
         e.init_path.write_text(EXAMPLE_CONFIG, encoding="utf-8")
         console.print(f'Config "{e.init_path.stem}" created at "{e.init_path}"')
 


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Create the parent directory for the configuration when running `organize new` the first time.

- Update cli.py.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

I couldn't find an already open issue.

## Checklist

- [ ] Tests for the changes exist and pass on CI
- [x] Documentation reflects the changes where applicable
- [x] Change is documented in CHANGELOG.md (if applicable)
- [ ] My PR is ready to review
