### PR TITLE
Add `deduplicate` conflict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added a new conflict mode `deduplicate` which skips duplicate files amd renames non-duplicates
 
 ## v3.2.5 (2024-07-09)
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -58,6 +58,21 @@ rules:
           on_conflict: overwrite
 ```
 
+Use a placeholder to copy all .pdf files into a "PDF" folder and all .jpg files into a "JPG" folder. If two files share the same file name and are duplicates, the duplicate will be skipped. If they aren't duplicates, the second file will be renamed.
+
+```yaml
+rules:
+  - locations: ~/Desktop
+    filters:
+      - extension:
+          - pdf
+          - jpg
+    actions:
+      - copy:
+          dest: "~/Desktop/{extension.upper()}/"
+          on_conflict: deduplicate
+```
+
 Copy into the folder `Invoices`. Keep the filename but do not overwrite existing files.
 To prevent overwriting files, an index is added to the filename, so `somefile.jpg` becomes `somefile 2.jpg`.
 The counter separator is `' '` by default, but can be changed using the `counter_separator` property.

--- a/organize/actions/common/conflict.py
+++ b/organize/actions/common/conflict.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple
+import filecmp
 
 from organize.output import Output
 from organize.resource import Resource
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from jinja2 import Template
 
 # TODO: keep_newer, keep_older, keep_bigger, keep_smaller
-ConflictMode = Literal["skip", "overwrite", "trash", "rename_new", "rename_existing"]
+ConflictMode = Literal["skip", "overwrite", "deduplicate", "trash", "rename_new", "rename_existing"]
 
 
 class ConflictResult(NamedTuple):
@@ -103,6 +104,17 @@ def resolve_conflict(
 
             delete(path=dst)
         return ConflictResult(skip_action=False, use_dst=dst)
+    
+    elif conflict_mode == "deduplicate":
+        if filecmp.cmp(res.path, dst, shallow=True):
+            _print(f"Duplicate skipped.")
+            return ConflictResult(skip_action=True, use_dst=res.path)
+        else:
+            new_path = next_free_name(
+                dst=dst,
+                template=rename_template,
+            )
+            return ConflictResult(skip_action=False, use_dst=new_path)
 
     elif conflict_mode == "rename_new":
         new_path = next_free_name(

--- a/tests/actions/test_copy.py
+++ b/tests/actions/test_copy.py
@@ -136,6 +136,44 @@ def test_copy_conflict(fs, mode, result):
     Config.from_string(config).execute(simulate=False)
     assert read_files("test") == result
 
+def test_copy_deduplicate_conflict(fs):
+    files = {
+        "src.txt": "src",
+        "duplicate": {
+            "src.txt": "src",
+        },
+        "nonduplicate": {
+            "src.txt": "src2",
+        },
+    }
+
+    config = """
+    rules:
+      - locations: "/test"
+        subfolders: true
+        filters:
+          - name: src
+        actions:
+          - copy:
+              dest: "/test/dst.txt"
+              on_conflict: deduplicate
+    """
+    make_files(files, "test")
+
+    Config.from_string(config).execute(simulate=False)
+    result = read_files("test")
+    
+    assert result == {
+        "src.txt": "src",
+        "duplicate": {
+            "src.txt": "src",
+        },
+        "nonduplicate": {
+            "src.txt": "src2",
+        },
+        "dst.txt": "src",
+        "dst 2.txt": "src2",
+    }
 
 def test_does_not_create_folder_in_simulation(fs):
     config = """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

I added a new conflict mode called `deduplicate` that acts as a hybrid of skip and rename_new. When the conflicting files are the same per [filecmp](https://docs.python.org/3/library/filecmp.html) it'll skip the new one, and if they're different it'll rename them.

This can be helpful when sorting a large number of files at once while minimizing duplicates, without accidentally overwriting actual data.

## Related issue number

I believe this would resolve #277.

## Checklist

- [x] Tests for the changes exist and pass on CI
- [x] Documentation reflects the changes where applicable
- [x] Change is documented in CHANGELOG.md (if applicable)
- [x] My PR is ready to review
