### PR TITLE
Fixes filter fails for PDFs when `pdftotext` isn't installed instead of falling back to `pdfminer`

### DIFF
--- a/organize/filters/filecontent.py
+++ b/organize/filters/filecontent.py
@@ -54,7 +54,7 @@ def _is_executable(name: str, *args) -> bool:
             stderr=subprocess.STDOUT,
         )
         return True
-    except subprocess.CalledProcessError:
+    except (FileNotFoundError, subprocess.CalledProcessError):
         return False
 
 

--- a/organize/filters/filecontent.py
+++ b/organize/filters/filecontent.py
@@ -40,15 +40,21 @@ def extract_txt(path: Path) -> str:
 @lru_cache(maxsize=1)
 def _pdftotext_available() -> bool:
     # check whether the given path is executable
+    ok = _is_executable("pdftotext", "-v")
+    if not ok:
+        logger.warning("pdftotext not available. Falling back to pdfminer library.")
+    return ok
+
+
+def _is_executable(name: str, *args) -> bool:
     try:
         subprocess.check_call(
-            ["pdftotext", "-v"],
+            [name, *args],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.STDOUT,
         )
         return True
     except subprocess.CalledProcessError:
-        logger.warning("pdftotext not available. Falling back to pdfminer library.")
         return False
 
 

--- a/organize/filters/filecontent.py
+++ b/organize/filters/filecontent.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 import subprocess
 from functools import lru_cache
 from pathlib import Path
@@ -40,22 +41,14 @@ def extract_txt(path: Path) -> str:
 @lru_cache(maxsize=1)
 def _pdftotext_available() -> bool:
     # check whether the given path is executable
-    ok = _is_executable("pdftotext", "-v")
+    ok = _is_executable("pdftotext")
     if not ok:
         logger.warning("pdftotext not available. Falling back to pdfminer library.")
     return ok
 
 
-def _is_executable(name: str, *args) -> bool:
-    try:
-        subprocess.check_call(
-            [name, *args],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.STDOUT,
-        )
-        return True
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return False
+def _is_executable(name: str) -> bool:
+    return shutil.which(name) is not None
 
 
 def _extract_with_pdftotext(path: Path, keep_layout: bool) -> str:

--- a/tests/filters/test_filecontent.py
+++ b/tests/filters/test_filecontent.py
@@ -3,6 +3,18 @@ from conftest import make_files, read_files
 from organize import Config
 
 
+def test_is_executable():
+    from organize.filters.filecontent import _is_executable as is_executable
+
+    import sys
+    present_exe = 'dir' if hasattr(sys, 'getwindowsversion') else 'ls'
+    assert is_executable(present_exe)
+
+    from uuid import uuid1 as uuid
+    absent_exe = f"no-such-executable-{uuid()}" # random name that won't exist
+    assert not is_executable(absent_exe)
+
+
 def test_filecontent(fs):
     # inspired by https://github.com/tfeldmann/organize/issues/43
     files = {


### PR DESCRIPTION
Fixes #437.

<!-- Thank you for your contribution! -->

## Change Summary

- Uses `shutil.which` instead of `subprocess.check_call` to check if an executable exists.

<!-- Please give a short summary of the changes. -->

## Checklist

- [ ] Tests for the changes exist and pass on CI
- [ ] Documentation reflects the changes where applicable
- [ ] Change is documented in CHANGELOG.md (if applicable)
- [ ] My PR is ready to review
