### PR TITLE
feat: added support for filtering by download URL (macOS only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed #438 (`filecontent` filter fails for PDFs when `pdftotext` isn't installed, instead of falling back to `pdfminer`)
+- New filter: `macos_downloadsource` (macOS only).
 
 ## v3.3.0 (2024-11-25)
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -501,6 +501,33 @@ rules:
       - echo: "{macos_tags}"
 ```
 
+## macos_downloadsource
+
+::: organize.filters.MacOSDownloadSource
+
+**Examples:**
+
+```yaml
+rules:
+  - name: "List all files downloaded from example.com"
+    locations: "~/Downloads"
+    filters:
+      - macos_downloadsource:
+        - "https://example.com/*"
+    actions:
+      - echo: "File downloaded from example.com"
+```
+
+```yaml
+rules:
+  - name: "Listing files that were downloaded installed of created locally"
+    locations: "~/Downloads"
+    filters:
+      - macos_downloadsource
+    actions:
+      - echo: "{path}"
+```
+
 ## mimetype
 
 ::: organize.filters.MimeType

--- a/organize/filters/__init__.py
+++ b/organize/filters/__init__.py
@@ -9,6 +9,7 @@ from .filecontent import FileContent
 from .hash import Hash
 from .lastmodified import LastModified
 from .macos_tags import MacOSTags
+from .macos_downloadsource import MacOSDownloadSource 
 from .mimetype import MimeType
 from .name import Name
 from .python import Python
@@ -27,6 +28,7 @@ ALL = (
     Hash,
     LastModified,
     MacOSTags,
+    MacOSDownloadSource,
     MimeType,
     Name,
     Python,

--- a/organize/filters/macos_downloadsource.py
+++ b/organize/filters/macos_downloadsource.py
@@ -1,0 +1,75 @@
+import sys
+import json
+from typing import ClassVar, List
+
+from pydantic import Field, field_validator
+from pydantic.config import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from organize.filter import FilterConfig
+from organize.output import Output
+from organize.resource import Resource
+from organize.utils import glob_match
+
+
+def list_download_urls(path) -> List[str]:
+    import osxmetadata
+    urls = json.loads(osxmetadata.OSXMetaData(path).to_json())["kMDItemWhereFroms"]
+    return urls
+
+
+def convert_to_list(v):
+    if not v:
+        return []
+    if isinstance(v, str):
+        return v.split()
+    return v
+
+
+def match_urls(filter_urls, file_urls) -> bool:
+    if file_urls is None:
+        return False
+    if not filter_urls:
+        return True
+    urls = [url.replace("blob:", "") for url in file_urls]
+    for url in urls:
+        if any(glob_match(filter_url, url) for filter_url in filter_urls):
+            return True
+    return False
+
+
+@dataclass(config=ConfigDict(coerce_numbers_to_str=True, extra="forbid"))
+class MacOSDownloadSource:
+    """Filter files using the "kMDItemWhereFroms" metadata present in macOS files. 
+    This allows us to check where the file originated from (if such metadata exists)
+ 
+    Attributes:
+        urls (list(str) or str):
+            The source URLs to filter by
+    """
+
+    urls: List[str] = Field(default_factory=list)
+
+    filter_config: ClassVar[FilterConfig] = FilterConfig(
+        name="macos_downloadsource",
+        files=True,
+        dirs=True,
+    )
+
+    def __post_init__(self):
+        if sys.platform != "darwin":
+            raise EnvironmentError("The macos_downloadsource filter is only available on macOS")
+
+    @field_validator("urls", mode="before")
+    def normalise_urls(cls, v):
+        as_list = convert_to_list(v)
+        return set(list(as_list))
+
+    def pipeline(self, res: Resource, output: Output) -> bool:
+        if res.is_dir():
+            raise ValueError("Directories are not supported")
+
+        file_urls = list_download_urls(res.path)
+
+        res.vars[self.filter_config.name] = file_urls
+        return match_urls(filter_urls=self.urls, file_urls=file_urls)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "exifread==2.3.2",
     "jinja2>=3.1.2,<4.0.0",
     "macos-tags>=1.5.1,<2.0.0 ; sys_platform == 'darwin'",
+    "osxmetadata>=1.3.0; sys_platform == 'darwin'",
     "natsort>=8.4.0,<9.0.0",
     "pdfminer-six>=20231228",
     "platformdirs>=4.0.0,<5.0.0",
@@ -90,6 +91,7 @@ module = [
     "textract",
     "requests",
     "macos_tags",
+    "osxmetadata",
 ]
 ignore_missing_imports = true
 

--- a/tests/filters/test_macos_downloadsources.py
+++ b/tests/filters/test_macos_downloadsources.py
@@ -1,0 +1,61 @@
+import sys
+
+import pytest
+
+from organize import Config
+from organize.filters.macos_downloadsource import list_download_urls, match_urls
+
+
+def test_macos_downloadsource_matching():
+    filter_urls = ["https://*.githubusercontent.com/*"]
+    assert not match_urls(filter_urls=filter_urls, file_urls=["https://github.com"])
+    assert not match_urls(filter_urls=filter_urls, file_urls=None)
+    assert match_urls(filter_urls=filter_urls, file_urls=["https://raw.githubusercontent.com/nonexistentlink"])
+    assert match_urls(filter_urls=[], file_urls=["https://github.com"])
+    assert not match_urls(filter_urls=[], file_urls=None)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="runs only on macos")
+def test_macos_downloadsource_filter(tmp_path, testoutput):
+    import osxmetadata
+
+
+    testdir = tmp_path / "test"
+    testdir.mkdir()
+
+    selfmade = testdir / "test.txt"
+    selfmade.touch()
+    assert list_download_urls(selfmade) is None
+
+    # These tests currently doesn't work as Spotlight does not re-index files in `/tmp` or `/private/var/tmp` when new metadata is set. 
+
+    # example_file = testdir / "example.txt"
+    # example_file.touch()
+    # osxmetadata.OSXMetaData(example_file).set("kMDItemWhereFroms", ["https://example.com", ""])
+    # assert list_download_urls(example_file) == ["https://example.com", ""]
+
+    # Workaround, see below
+    from os.path import expanduser
+    import random
+    import string
+    example_file = f"""{expanduser("~")}/{''.join([string.ascii_letters[random.randint(0, len(string.ascii_letters)-1)] for _ in range (20)])}.txt"""
+    with open(example_file, 'w') as f:
+        f.write("")
+    osxmetadata.OSXMetaData(example_file).set("kMDItemWhereFroms", ["https://example.com", ""])
+    import time
+    time.sleep(3)
+    assert list_download_urls(example_file) == ["https://example.com", ""]
+
+    Config.from_string(
+            f"""
+            rules:
+              - locations: ~/
+                filters:
+                - macos_downloadsource:
+                actions:
+                - echo: "{{'|<>|'.join(macos_downloadsource)}}"
+                - delete
+            """
+    ).execute(simulate=False, output=testoutput)
+
+    assert testoutput.messages == ["https://example.com|<>|", f"Deleting {example_file}"]


### PR DESCRIPTION
I've been using Hazel during the 5.x versions and relied quite heavily on the ability to sort files by where they were downloaded from.

This commit adds support for filtering files on macOS by using the `kMDItemWhereFroms` metadata present in files downloaded.

The testcase is a little scuffed as processing file metadata requires the file to be in a location where Spotlight will reindex, and by default Spotlight does not index `/tmp` and `/private/var/tmp`

Also, `osxmetadata` is currently pinned to 1.3.0 due to some issues with dependencies for 1.4.0

Let me know if there's anything I should edit! :)

<!-- Thank you for your contribution! -->

## Change Summary

- introduce `macos_downloadsource` as a filter
<!-- Please give a short summary of the changes. -->

## Related issue number

Not that I'm aware of
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

- [x] Tests for the changes exist and pass on CI
- [x] Documentation reflects the changes where applicable
- [x] Change is documented in CHANGELOG.md (if applicable)
- [x] My PR is ready to review
