### PR TITLE
deps: switch from docx2txt to maintained docx2python

### DIFF
--- a/organize/filters/filecontent.py
+++ b/organize/filters/filecontent.py
@@ -73,10 +73,10 @@ def extract_pdf(path: Path, keep_layout: bool = True) -> str:
 
 
 def extract_docx(path: Path) -> str:
-    import docx2txt  # type: ignore
+    from docx2python import docx2python  # type: ignore
 
-    result = docx2txt.process(path)
-    return clean(result)
+    doc = docx2python(str(path))
+    return clean(doc.text)
 
 
 EXTRACTORS: Dict[str, Callable[[Path], str]] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "arrow>=1.3.0,<2.0.0",
     "docopt-ng>=0.9.0,<1.0.0",
-    "docx2txt>=0.8,<=0.9",
+    "docx2python>=2.12.0,<3.0.0",
     "exifread==2.3.2",
     "jinja2>=3.1.2,<4.0.0",
     "macos-tags>=1.5.1,<2.0.0 ; sys_platform == 'darwin'",


### PR DESCRIPTION
Switch from unmaintained python-docx2txt to the actively maintained [docx2python](https://github.com/ShayHill/docx2python) fork.

**Rationale:**
- python-docx2txt has not seen any maintenance activity
- docx2python is actively maintained with recent releases
- API is compatible with a simple change from  to 

**Changes:**
- : replace  with 
- : update  to use docx2python API

**Testing:**
- The API change is minimal:  → 
- Both return clean text output from .docx files

Closes #475