### PR TITLE
Add new filter: one_per

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -19,22 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        # action version v6.2.0, SHA=dc802804100637a589fabce1cb79ff13a1411302
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: tfeldmann/organize
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7.3.0
         with:
           push: true
           tags: tfeldmann/organize:latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Version info
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Version info
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+      - oneper
   workflow_dispatch:
 
 jobs:
@@ -18,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
     branches:
       - main
-      - oneper
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: Version info
         run: |

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -610,6 +610,115 @@ rules:
       - echo: "Found a match."
 ```
 
+## one_per
+
+::: organize.filters.OnePer
+
+**Examples:**
+
+Show backup files in a folder that are *not* the earliest backup for any given 
+day.
+
+Given files in `~/backups`:
+```
+file          last modified
+file.1.bkup   June 1 12:01
+file.2.bkup   June 1 15:21
+file.3.bkup   June 1 09:13
+file.4.bkup   June 2 02:02
+file.5.bkup   June 2 08:11
+file.6.bkup   June 2 10:22
+file.7.bkup   June 2 10:33
+```
+
+```yaml
+rules:
+  - name: find extra backup files by day
+    locations:
+      - ~/backups
+    filters:
+      - one_per:
+          detect_the_one_by: lastmodified
+          period: day
+    action:
+      - echo: "{path} is an extra in the same day as {one_per.the_one}"
+```
+
+Output:
+
+- `file.2.bkup is an extra in the same day as file.1.bkup`
+- `file.1.bkup is an extra in the same day as file.3.bkup`
+- `file.5.bkup is an extra in the same day as file.4.bkup`
+- `file.6.bkup is an extra in the same day as file.4.bkup`
+- `file.7.bkup is an extra in the same day as file.4.bkup`
+
+Result summary:
+- June 1: `the_one` is `file.3.bkup`, files emitted by the filter are (in order):
+  `file.2.bkup`, `file.1.bkup`
+- June 2: `the_one` is `file.4.bkup`, files emitted are: `file.5.bkup`,
+  `file.6.bkup`, `file.7.bkup`
+
+Keep one backup file per hour, removing other backups created in the same hour,
+where the file to be kept is determined by the file name, which includes a
+timestamp. (E.g., "~/backups/backup-20260623-151359")
+
+```yaml
+rules:
+  - name: find extra backup files by name, keep last one per hour
+    locations:
+      - ~/backups
+    filters:
+      - one_per:
+          detect_the_one_by: -name # keep the file that is alphabetically last
+          period: hour
+    action:
+      - echo: "{path} is an extra in the same hour as {one_per.the_one}"
+      - trash
+```
+
+Here is a more complicated example to show how multiple filters can be combined
+to allow finer periods to be filtered.
+
+Keep earliest backup per each 30 minute period, within the current clock hour
+(e.g., if the current time is 15:59, then keep the first file between 15:00 and
+15:29, and earliest between 15:30 and 15:59):
+
+```yaml
+rules:
+  - name: "00-29"
+    locations:
+      - ~/backups
+    filters:
+      # include only files updated between minutes "00" and "30" of current hour
+      - python: |
+          import arrow
+          now = arrow.now()
+          earliest = now.floor("hour")
+          latest = earliest.shift(minutes=30)
+          ts = arrow.get(path.stat().st_mtime)
+          return (ts >= earliest) and (ts < latest)
+      # one_per with default method of `lastmodified` and period of `hour`
+      - one_per
+    actions:
+      - trash
+  - name: "30-59"
+    locations:
+      - ~/backups
+    filters:
+      # include only files updated between minutes "30" and "59" of current hour
+      - python: |
+          import arrow
+          now = arrow.now()
+          earliest = now.floor("hour").shift(minutes=30)
+          latest = earliest.shift(minutes=30)
+          ts = arrow.get(path.stat().st_mtime)
+          return (ts >= earliest) and (ts < latest)
+      # one_per with default method of `lastmodified` and period of `hour`
+      - one_per
+    actions:
+      - trash
+```
+
 ## python
 
 ::: organize.filters.Python

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -640,7 +640,7 @@ rules:
       - one_per:
           detect_the_one_by: lastmodified
           period: day
-    action:
+    actions:
       - echo: "{path} is an extra in the same day as {one_per.the_one}"
 ```
 
@@ -671,7 +671,7 @@ rules:
       - one_per:
           detect_the_one_by: -name # keep the file that is alphabetically last
           period: hour
-    action:
+    actions:
       - echo: "{path} is an extra in the same hour as {one_per.the_one}"
       - trash
 ```

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -616,7 +616,7 @@ rules:
 
 **Examples:**
 
-Show backup files in a folder that are *not* the earliest backup for any given 
+Show backup files in a folder that are *not* the earliest backup for any given
 day.
 
 Given files in `~/backups`:

--- a/organize/filters/__init__.py
+++ b/organize/filters/__init__.py
@@ -11,6 +11,7 @@ from .lastmodified import LastModified
 from .macos_tags import MacOSTags
 from .mimetype import MimeType
 from .name import Name
+from .one_per import OnePer
 from .python import Python
 from .regex import Regex
 from .size import Size
@@ -29,6 +30,7 @@ ALL = (
     MacOSTags,
     MimeType,
     Name,
+    OnePer,
     Python,
     Regex,
     Size,

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -171,9 +171,10 @@ class OnePer:
         # filter instance is configured.
         self.get_timestamp_floor: Callable[[Arrow], Arrow]
         if "week" == self.period:
-            self.get_timestamp_floor = self.get_timestamp_floor_week
             if self.week_start is None:
                 self.week_start = 7
+            self._shift_days = -1 if self.week_start == 7 else (self.week_start - 1)
+            self.get_timestamp_floor = self.get_timestamp_floor_week
         else:
             assert self.week_start is None, '`"week_start"` invalid for non-week period'
             self.get_timestamp_floor = self.get_timestamp_floor_non_week
@@ -199,11 +200,23 @@ class OnePer:
     def get_timestamp_floor_week(self, timestamp: Arrow) -> Arrow:
         """Get the period for a file timestamp when the period is `"week"`
 
-        The user can configure to use any day of the week as the start.
+        The user can configure `"week_start"` to use any day of the week as the
+        start.
+
+        NOTE: arrow version >= 1.4 adds a parameter to the `Arrow.floor()`
+              method to specify the start day of the week, but in arrow@1.3.0,
+              the current version used by this project, that parameter is not
+              available. As a result, we implement the same behavior by taking
+              the default week start of Monday and shifting it. We pre-calculate
+              the days to shift it in the `__post_init__()` method, because
+              the value won't change after the filter is configured. For Sunday,
+              which has an isoweekday value of 7, we shift it by `-1` days. All
+              other days are shifted by `week_start - 1`.
 
         This follows isoweekday() where Monday is 1 and Sunday is 7.
         """
-        return timestamp.floor(self.period, week_start=self.week_start)
+        period = timestamp.floor("week")
+        return period.shift(days=self._shift_days)
 
     def get_period(self, file: Path) -> tuple[Arrow, Arrow]:
         """get the timestamp for the file and the period for the timestamp

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -38,20 +38,26 @@ DetectionMethod = Literal[
 class OnePer:
     """Group files by modification time.
 
-    This filter finds files that were modified in a given time period, except
-    for the earliest file from the time period.
+    This filter creates groups files that were modified in a given time period.
+    It emits the "extra" files per group, and does not emit the "earliest" file
+    of the group. The "earliest" file is available as `{one_per.the_one}`, but
+    beware that the value of this can change as more files are processed.
+
+    The time period is based on the `lastmodified` timestamp for all methods,
+    except for the `created` method.
 
     Attributes:
         detect_the_one_by (str):
-            Detection method to distinguish between original and duplicate.
+            Detection method to distinguish between earliest and extra.
             Possible values are:
 
-            - `"first_seen"`: Whatever file is visited first is the original. This
-              depends on the order of your location entries.
-            - `"name"`: The first entry sorted by name is the original.
-            - `"created"`: The first entry sorted by creation date is the original.
-            - `"lastmodified"`: The first file sorted by date of last modification is
-               the original.
+            - `"first_seen"`: Whatever file is visited first is the earliest.
+              This depends on the order of your location entries.
+            - `"name"`: The first entry sorted by name is the earliest.
+            - `"created"`: The first entry sorted by creation date is the
+              earliest; the period is determined by the creation timestamp.
+            - `"lastmodified"`: The first file sorted by date of last
+              modification is the earliest.
 
         period (str):
             The period to group files into.
@@ -62,6 +68,61 @@ class OnePer:
             - `"hour"`
             - `"day"`
             - `"month"`
+
+    You can reverse the sorting method by prefixing a `-`.
+
+    So with `detect_the_one_by: "-created"` the file with the older creation
+    date is "the one" and the younger file is the extra. This works on all
+    methods, for example `"-first_seen"`, `"-name"`, `"-created"`,
+    `"-lastmodified"`.
+
+    **Example and explanation:**
+
+    Given the following files in a directory, where `my_file.txt` has been
+    edited several times, and each time it is saved, a new backup file is
+    created:
+    ```
+    name                  last modified
+    -----------------------------------
+    my_file.txt           June 25 15:01
+    my_file.txt~1         June 23 13:23
+    my_file.txt~2         June 23 14:03
+    my_file.txt~3         June 24 11:23
+    my_file.txt~4         June 24 11:47
+    my_file.txt~5         June 24 11:53
+    my_file.txt~6         June 25 13:23
+    ```
+
+    The user might not need to keep every single backup file, but may wish to
+    "thin" them out. The backups are not dependant on each other, so it is safe
+    to remove any particular file.
+
+    If the rule is for a period of `hour`, and a method of `lastmodified`, and
+    there is a name filter to process files in the directory that contains `~`,
+    then:
+
+      Periods found are:
+      - June 23, 13:00:00 - 13:59:59
+        - `the_one`: `my_file.txt~1`
+        - extra files emitted: None
+      - June 23, 14:00:00 - 14:59:59
+        - `the_one`: `my_file.txt~2`
+        - extra files emitted: None
+      - June 24, 11:00:00 - 11:59:59
+        - `the_one`: `my_file.txt~3`
+        - extra files emitted: `my_file.txt~4`, `my_file.txt~5`
+      - June 25, 13:00:00 - 13:59:59
+        - `the_one`: `my_file.txt~6`
+        - extra files emitted: None
+
+    If this rule is set to delete or trash files emitted by the filter, then
+    `my_file.txt~4` and `my_file.txt~5` will be removed, and the other files
+    (`the_one` for each period) would be kept.
+
+    **Returns:**
+
+    `{one_per.the_one}` - The path to the "earliest" file found so far from the
+    same period as the file currently being processed
     """
 
     period: Period = "hour"

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -7,6 +7,8 @@ from pydantic.config import ConfigDict
 from pydantic.dataclasses import dataclass
 
 from organize.filter import FilterConfig
+from organize.filters.created import read_created
+from organize.filters.lastmodified import read_lastmodified
 from organize.output import Output
 from organize.resource import Resource
 
@@ -171,10 +173,10 @@ class OnePer:
         """
         if self._detect_the_one_by == "created":
             # if detection method is file creation time, use that as timestamp
-            ts = arrow_get(file.stat().st_ctime)
+            ts = arrow_get(read_created(file))
         else:
             # for all other detection methods, use the file modification time
-            ts = arrow_get(file.stat().st_mtime)
+            ts = arrow_get(read_lastmodified(file))
         # period for `path`
         period = ts.floor(self.period)
 

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -134,6 +134,8 @@ class OnePer:
         """
         if self._detect_the_one_by == "first_seen":
             it_is = False
+        elif self._detect_the_one_by == "name":
+            it_is = path < self._the_one_for_period[period]
         else:
             it_is = ts < self._ts_for_the_one[period]
         if self._detect_the_one_reverse:

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import ClassVar, Literal, Tuple
+from typing import Callable, ClassVar, Literal, Optional
+from typing import cast as type_cast
 
 from arrow import Arrow
 from arrow import get as arrow_get
@@ -15,6 +16,7 @@ from organize.resource import Resource
 # allowable values for `period`
 Period = Literal[
     "month",
+    "week",
     "day",
     "hour",
     "minute",
@@ -34,6 +36,8 @@ DetectionMethod = Literal[
     "lastmodified",
     "-lastmodified",
 ]
+
+WeekStart = Literal[1, 2, 3, 4, 5, 6, 7]
 
 
 @dataclass(config=ConfigDict(extra="forbid"))
@@ -69,7 +73,14 @@ class OnePer:
             - `"minute"`
             - `"hour"`
             - `"day"`
+            - `"week"`
             - `"month"`
+
+        week_start (int):
+            Only use with `period: "week"`. By default, a period of `week`
+            begins on Sunday. To use a different day, include this attribute.
+            Follows isoweekday() where Monday is 1 and Sunday is 7. (See the
+            documentation for the `arrow` python package for more details.)
 
     You can reverse the sorting method by prefixing a `-`.
 
@@ -129,32 +140,72 @@ class OnePer:
 
     period: Period = "hour"
     detect_the_one_by: DetectionMethod = "lastmodified"
+    # NOTE: cannot replace `Optional[WeekStart]` with future annotations and
+    #       `WeekStart | None` here, because in python 3.9, it will get a
+    #       runtime error, so we disable ruff and pylance type checking on
+    #       this line
+    week_start: Optional[WeekStart] = None  # noqa: FA100
 
     filter_config: ClassVar[FilterConfig] = FilterConfig(
         name="one_per", files=True, dirs=True
     )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """set up initial state of the filter, based on the filter options"""
-        self._detect_the_one_by = self.detect_the_one_by
+        self._detect_the_one_by: DetectionMethod = self.detect_the_one_by
         self._detect_the_one_reverse = False
         if self.detect_the_one_by.startswith("-"):
-            self._detect_the_one_by = self.detect_the_one_by[1:]
+            # DetectionMethods with "-" are all valid DetectionMethods
+            # after removing the "-" from the start, but we have to
+            # tell the typechecker that this is valid
+            self._detect_the_one_by = type_cast(
+                DetectionMethod, self.detect_the_one_by[1:]
+            )
             self._detect_the_one_reverse = True
+
+        # determine the correct function to get the floor
+        #
+        # choosing which method to use here is possibly slightly faster than
+        # test-and-branch on every individual file comparison. The period and
+        # the correct method for the timestamp floor will never change once the
+        # filter instance is configured.
+        self.get_timestamp_floor: Callable[[Arrow], Arrow]
+        if "week" == self.period:
+            self.get_timestamp_floor = self.get_timestamp_floor_week
+            if self.week_start is None:
+                self.week_start = 7
+        else:
+            assert self.week_start is None, '`"week_start"` invalid for non-week period'
+            self.get_timestamp_floor = self.get_timestamp_floor_non_week
 
         # track files we have already seen before
         self._seen_files: set[Path] = set()
         # for each period, the file that is "the_one"
-        self._the_one_for_period: dict[Arrow, Path] = dict()
+        self._the_one_for_period: dict[Arrow, Path] = {}
         # does our detection method need the timestamp?
         self._track_timestamps: bool = False
         if self._detect_the_one_by in ["created", "lastmodified"]:
             # this detection method uses the file timestamp, so keep it for
             # each period
-            self._ts_for_the_one: dict[Arrow, Arrow] = dict()
+            self._ts_for_the_one: dict[Arrow, Arrow] = {}
             self._track_timestamps = True
 
-    def get_period(self, file: Path) -> Tuple[Arrow, Arrow]:
+    def get_timestamp_floor_non_week(self, timestamp: Arrow) -> Arrow:
+        """
+        Get the period for a file timestamp for all periods (except `"week"`)
+        """
+        return timestamp.floor(self.period)
+
+    def get_timestamp_floor_week(self, timestamp: Arrow) -> Arrow:
+        """Get the period for a file timestamp when the period is `"week"`
+
+        The user can configure to use any day of the week as the start.
+
+        This follows isoweekday() where Monday is 1 and Sunday is 7.
+        """
+        return timestamp.floor(self.period, week_start=self.week_start)
+
+    def get_period(self, file: Path) -> tuple[Arrow, Arrow]:
         """get the timestamp for the file and the period for the timestamp
 
         A period is the earliest possible timestamp for grouping files that are
@@ -178,7 +229,7 @@ class OnePer:
             # for all other detection methods, use the file modification time
             ts = arrow_get(read_lastmodified(file))
         # period for `path`
-        period = ts.floor(self.period)
+        period = self.get_timestamp_floor(ts)
 
         return period, ts
 

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+from typing import ClassVar, Literal, assert_type
+
+import arrow
+from pydantic.config import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from organize.filter import FilterConfig
+from organize.output import Output
+from organize.resource import Resource
+
+Period = Literal[
+    "month",
+    "day",
+    "hour",
+    "minute",
+    "second",
+]
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class OnePer:
+    """Group files by modification time.
+
+    This filter finds files that were modified in a given time period, except
+    for the earliest file from the time period.
+
+    Attributes:
+        detect_original_by (str):
+            Detection method to distinguish between original and duplicate.
+            Possible values are:
+
+            - `"first_seen"`: Whatever file is visited first is the original. This
+              depends on the order of your location entries.
+            - `"name"`: The first entry sorted by name is the original.
+            - `"created"`: The first entry sorted by creation date is the original.
+            - `"lastmodified"`: The first file sorted by date of last modification is
+               the original.
+
+        period (str):
+            The period to group files into.
+            Possible values are:
+
+            - `"second"`
+            - `"minute"`
+            - `"hour"`
+            - `"day"`
+            - `""`
+    """
+
+    period: Period = "hour"
+    detect_the_one_by: str = "modified"
+
+    filter_config: ClassVar[FilterConfig] = FilterConfig(
+        name="one_per", files=True, dirs=True
+    )
+
+    def __post_init__(self):
+        assert_type(self.period, Period)
+
+        self._seen_files: set["os.PathLike"] = set()
+        self._the_one_for_period: dict["arrow.Arrow", "os.PathLike"] = dict()
+
+    def get_period(self, file: Path) -> arrow.Arrow:
+        ts = arrow.get(file.stat().st_mtime)
+        return ts.floor(self.period)
+
+    def pipeline(self, res: Resource, output: Output) -> bool:
+        assert res.path is not None, "Does not support standalone mode"
+
+        if res.path.is_symlink():
+            return False
+
+        if res.path in self._seen_files:
+            return False
+        self._seen_files.add(res.path)
+
+        period = self.get_period(res.path)
+        self._the_one_for_period[period] = res.path
+
+        return False

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -10,7 +10,6 @@ from organize.filter import FilterConfig
 from organize.output import Output
 from organize.resource import Resource
 
-
 # allowable values for `period`
 Period = Literal[
     "month",

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -132,7 +132,10 @@ class OnePer:
         :return: is `path` the new `the_one`
         :rtype: bool
         """
-        it_is = ts < self._ts_for_the_one[period]
+        if self._detect_the_one_by == "first_seen":
+            it_is = False
+        else:
+            it_is = ts < self._ts_for_the_one[period]
         if self._detect_the_one_reverse:
             return not it_is
         return it_is

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -1,8 +1,8 @@
-import os
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, Tuple
 
-import arrow
+from arrow import Arrow
+from arrow import get as arrow_get
 from pydantic.config import ConfigDict
 from pydantic.dataclasses import dataclass
 
@@ -10,12 +10,27 @@ from organize.filter import FilterConfig
 from organize.output import Output
 from organize.resource import Resource
 
+# allowable values for `period`
 Period = Literal[
     "month",
     "day",
     "hour",
     "minute",
     "second",
+]
+
+# allowable values for `detect_the_one_by`
+DetectionMethod = Literal[
+    "first_seen",
+    "-first_seen",
+    "last_seen",
+    "-last_seen",
+    "name",
+    "-name",
+    "created",
+    "-created",
+    "lastmodified",
+    "-lastmodified",
 ]
 
 
@@ -27,7 +42,7 @@ class OnePer:
     for the earliest file from the time period.
 
     Attributes:
-        detect_original_by (str):
+        detect_the_one_by (str):
             Detection method to distinguish between original and duplicate.
             Possible values are:
 
@@ -46,35 +61,160 @@ class OnePer:
             - `"minute"`
             - `"hour"`
             - `"day"`
-            - `""`
+            - `"month"`
     """
 
     period: Period = "hour"
-    detect_the_one_by: str = "modified"
+    detect_the_one_by: DetectionMethod = "lastmodified"
 
     filter_config: ClassVar[FilterConfig] = FilterConfig(
         name="one_per", files=True, dirs=True
     )
 
     def __post_init__(self):
-        self._seen_files: set["os.PathLike"] = set()
-        self._the_one_for_period: dict["arrow.Arrow", "os.PathLike"] = dict()
+        """set up initial state of the filter, based on the filter options"""
+        self._detect_the_one_by = self.detect_the_one_by
+        self._detect_the_one_reverse = False
+        if self.detect_the_one_by.startswith("-"):
+            self._detect_the_one_by = self.detect_the_one_by[1:]
+            self._detect_the_one_reverse = True
 
-    def get_period(self, file: Path) -> arrow.Arrow:
-        ts = arrow.get(file.stat().st_mtime)
-        return ts.floor(self.period)
+        # track files we have already seen before
+        self._seen_files: set[Path] = set()
+        # for each period, the file that is "the_one"
+        self._the_one_for_period: dict[Arrow, Path] = dict()
+        # does our detection method need the timestamp?
+        self._track_timestamps: bool = False
+        if self._detect_the_one_by in ["created", "lastmodified"]:
+            # this detection method uses the file timestamp, so keep it for
+            # each period
+            self._ts_for_the_one: dict[Arrow, Arrow] = dict()
+            self._track_timestamps = True
+
+    def get_period(self, file: Path) -> Tuple[Arrow, Arrow]:
+        """get the timestamp for the file and the period for the timestamp
+
+        A period is the earliest possible timestamp for grouping files that are
+        in the same group, regardless of whether we are looking for the oldest
+        or newest files.
+
+        Since we always have to get the timestamp in order to get the period, we
+        return it here so that we don't have to get it again if we need to use
+        it.
+
+        :param file: the path to the file whose period we want
+        :type file: Path
+
+        :return: a tuple with (period, timestamp)
+        :rtype: tuple
+        """
+        if self._detect_the_one_by == "created":
+            # if detection method is file creation time, use that as timestamp
+            ts = arrow_get(file.stat().st_ctime)
+        else:
+            # for all other detection methods, use the file modification time
+            ts = arrow_get(file.stat().st_mtime)
+        # period for `path`
+        period = ts.floor(self.period)
+
+        return period, ts
+
+    def is_the_one(self, period: Arrow, path: Path, ts: Arrow) -> bool:
+        """check if `path` should be the one
+
+        :param period: - the period for `path`
+        :type period: Arrow
+        :param path: - the file we are checking
+        :type path: Path
+        :param ts: - the timestamp for `path`
+        :type ts: Arrow
+
+        :return: is `path` the new `the_one`
+        :rtype: bool
+        """
+        it_is = ts < self._ts_for_the_one[period]
+        if self._detect_the_one_reverse:
+            return not it_is
+        return it_is
+
+    def update_the_one(self, period: Arrow, path: Path, ts: Arrow) -> None:
+        """update our internal tracker for `the_one`
+
+        :param period: - the period for `path`
+        :type period: Arrow
+        :param path: - the Path to `the_one`
+        :type path: Path
+        :param ts: - the timestamp for `path`
+        :type ts: Arrow
+        """
+        self._the_one_for_period[period] = path
+        if self._track_timestamps:
+            self._ts_for_the_one[period] = ts
 
     def pipeline(self, res: Resource, output: Output) -> bool:
+        """Process one file through this filter.
+
+        Since we are looking for files that can be grouped together by their
+        timestamps, this may emit:
+        - `False`, stop processing this file in other filters or actions
+        - `True`, process this file in other filters/actions
+        - `True`, process a different file in other filters/actions
+
+        The actual file that gets processed further down the pipeline is
+        identified by this method returning `True`, and by the value of
+        `res.path`. We can change which file other pipelines will process by
+        updating `res`.
+
+        :param res: the Resource for this filter to process; this might be
+                    modified to force futher pipelines to use a different
+                    Resource
+        :type res: Resource
+        :param output: not used in this filter
+        :type output: Output
+        :return: continue processing `res` in other filters/actions
+        :rtype: bool
+        """
         assert res.path is not None, "Does not support standalone mode"
 
+        # skip if symlink
         if res.path.is_symlink():
             return False
 
+        # skip if we have already processed this file
         if res.path in self._seen_files:
             return False
         self._seen_files.add(res.path)
 
-        period = self.get_period(res.path)
-        self._the_one_for_period[period] = res.path
+        # get the period for this file
+        period, ts = self.get_period(res.path)
 
-        return False
+        # get the_one, if this is the first file in period, it is the_one
+        the_one = self._the_one_for_period.get(period, res.path)
+
+        # assume we do not want to continue processing this file
+        process_it: bool = False
+
+        if the_one != res.path:
+            # if the_one is different from current file, at least one of them
+            # will be processed (can only be same for first file)
+            process_it = True
+
+            # compare against current one for this period
+            if self.is_the_one(period, res.path, ts):
+                # this file is the new the_one
+                previous = the_one
+                new_one = res.path
+
+                # save the_one and its timestamp
+                self.update_the_one(period, res.path, ts)
+
+                # switch which file gets processed
+                res.path = previous
+                the_one = new_one
+        else:
+            # no files in this period yet, this one is the one
+            self.update_the_one(period, the_one, ts)
+
+        # done processing, update vars and return value
+        res.vars[self.filter_config.name] = {"the_one": the_one}
+        return process_it

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import ClassVar, Literal, assert_type
+from typing import ClassVar, Literal
 
 import arrow
 from pydantic.config import ConfigDict
@@ -57,8 +57,6 @@ class OnePer:
     )
 
     def __post_init__(self):
-        assert_type(self.period, Period)
-
         self._seen_files: set["os.PathLike"] = set()
         self._the_one_for_period: dict["arrow.Arrow", "os.PathLike"] = dict()
 

--- a/organize/filters/one_per.py
+++ b/organize/filters/one_per.py
@@ -10,6 +10,7 @@ from organize.filter import FilterConfig
 from organize.output import Output
 from organize.resource import Resource
 
+
 # allowable values for `period`
 Period = Literal[
     "month",

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -18,6 +18,7 @@ file creation timestamp for grouping files together.
 """
 
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -17,12 +17,15 @@ file creation timestamp for grouping files together.
   the files in a specific order, and having a delay in between creating files.
 """
 
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
 import time
+from collections.abc import Generator
 from pathlib import Path
-from typing import Callable, Generator, List, Optional, Union
+from typing import Callable, Union
 
 import pytest
 from arrow import Arrow
@@ -33,24 +36,38 @@ from pyfakefs.fake_filesystem_unittest import Patcher
 
 from organize import Config
 from organize.filters import OnePer
-from organize.filters.one_per import DetectionMethod, Period
+from organize.filters.one_per import DetectionMethod, Period, WeekStart
 from organize.output import Default as Output
 from organize.resource import Resource
 
 FakeOrTmpFileSystem = Union[FakeFilesystem, Path]
 
+AllPeriods = ["month", "week", "day", "hour", "minute", "second"]
 
-@pytest.fixture(params=["month", "day", "hour", "minute", "second"])
+
+@pytest.fixture(params=AllPeriods)
 def period(request) -> Period:
     """fixture to loop over valid periods"""
+    return request.param
+
+
+@pytest.fixture(params=[p for p in AllPeriods if p != "week"])
+def non_week_period(request) -> Period:
+    """fixture to loop over periods but skip `"week"`"""
+    return request.param
+
+
+@pytest.fixture(params=[i + 1 for i in range(7)])
+def week_start(request) -> WeekStart:
+    """fixture to loop over valid `week_start` values: 1-7"""
     return request.param
 
 
 def make_fake_path(
     fs: FakeOrTmpFileSystem,
     file: str,
-    mtime: Optional[Arrow] = None,
-    ctime: Optional[Arrow] = None,
+    mtime: Arrow | None = None,
+    ctime: Arrow | None = None,
     _last: bool = False,
 ) -> Path:
     """create a fake file with optional timestamps
@@ -88,8 +105,8 @@ def make_fake_path(
 def make_tmp_path(
     tmp_path: FakeOrTmpFileSystem,
     file: str,
-    mtime: Optional[Arrow] = None,
-    ctime: Optional[Arrow] = None,
+    mtime: Arrow | None = None,
+    ctime: Arrow | None = None,
     last: bool = False,
 ) -> Path:
     """Create a real file in a temporary location.
@@ -148,11 +165,11 @@ def make_tmp_path(
 
 
 def make_files_with_relative_ts(
-    my_fs: Union[FakeFilesystem, Path],
-    offsets: List[int],
-    order: Optional[List[int]],
+    my_fs: FakeFilesystem | Path,
+    offsets: list[int],
+    order: list[int] | None,
     maker: Callable[
-        [FakeOrTmpFileSystem, str, Optional[Arrow], Optional[Arrow], bool],
+        [FakeOrTmpFileSystem, str, Arrow | None, Arrow | None, bool],
         Path,
     ] = make_fake_path,
 ) -> list[Path]:
@@ -172,9 +189,9 @@ def make_files_with_relative_ts(
     :param maker: a function used to create the files; one version uses
          pyfakefs, and the other version uses real tmp files
     """
-    ctime: Optional[Arrow] = None
+    ctime: Arrow | None = None
     now = Arrow(2026, 7, 12, 15)
-    paths: List[Path] = list()
+    paths: list[Path] = []
     count = len(offsets)
     for idx in range(count):
         i = order[idx] if order else idx
@@ -192,7 +209,7 @@ def make_files_with_relative_ts(
 
 @pytest.fixture
 def files_with_relative_ts(
-    fs, offsets: List[int], order: Optional[List[int]]
+    fs, offsets: list[int], order: list[int] | None
 ) -> list[Path]:
     """fixture to create several files with timestamps
 
@@ -227,7 +244,7 @@ def files_with_relative_ts(
 def may_need_real_files(
     tmp_path,
     offsets: list[int],
-    order: Optional[list[int]],
+    order: list[int] | None,
 ) -> Generator[list[Path], None, None]:
     """create files where we care about the creation timestamp
 
@@ -287,18 +304,18 @@ def may_need_real_files(
         yield make_files_with_relative_ts(tmp_path, offsets, order, maker=make_tmp_path)
 
 
-def rename_paths(paths: List[Path], names: List[str]) -> List[Path]:
+def rename_paths(paths: list[Path], names: list[str]) -> list[Path]:
     """rename a list of files to a list of new file names
 
     :param paths: list of Paths to files that exist
-    :type paths: List[Path]
+    :type paths: list[Path]
     :param names: list of strings to be used to rename files in `paths`
-    :type names: List[str]
+    :type names: list[str]
 
     :return: the new list of Paths to the renamed files
-    :rtype: List[Path]
+    :rtype: list[Path]
     """
-    named_paths: List[Path] = list()
+    named_paths: list[Path] = []
     for i in range(len(names)):
         named = paths[i]
         # create a new Path that points to the new name
@@ -370,13 +387,19 @@ def test_invalid_period():
 
 def test_tracks_file_period(fs, period):
     """filtering a file should track the file's period"""
+    ## arrange
     op = OnePer(period=period)
 
     ## organize
     # possible time stamps
     now = Arrow(2026, 6, 26, 17, 8, 32, 123)
     # expected period for the file
-    file_period = now.floor(period)
+    file_period = (
+        now.floor(period)
+        if "week" != period
+        # the filter defaults to non-iso start on Sunday
+        else now.floor(period, week_start=7)
+    )
     f = make_fake_path(fs, "/f", now)
 
     ## act
@@ -393,10 +416,75 @@ def test_tracks_file_period(fs, period):
     assert op._the_one_for_period[file_period] is f
 
 
+def test_week_start(fs, week_start):
+    """user can specify a different day to start the week on"""
+    ## arrange
+    op = OnePer(period="week", week_start=week_start)
+
+    # possible time stamps
+    now = Arrow(2026, 6, 26, 17, 8, 32, 123)
+    # expected period for the file
+    file_period = now.floor("week", week_start=week_start)
+    f = make_fake_path(fs, "/f", now)
+
+    ## act
+    processed = op.pipeline(Resource(f), Output())
+
+    ## assert
+    # one file should not find extras to process
+    assert not processed
+
+    # the period for the file should be known
+    assert file_period in op._the_one_for_period
+
+    # with only one file, it should be the one for its period
+    assert op._the_one_for_period[file_period] is f
+
+    # the filter should be configured with the correct week_start
+    assert op.week_start == week_start
+
+
+def test_week_period_defaults_to_Sunday():
+    """when no `week_start` provided, default to Sunday"""
+    ## arrange
+    op = OnePer(period="week")
+
+    ## assert
+    assert op.week_start == 7
+
+
+def test_cannot_specify_week_start_on_other_periods(non_week_period, week_start):
+    """exception should be raised if `week_start` provided for non-week period"""
+    try:
+        OnePer(period=non_week_period, week_start=week_start)
+        assert False, "Unexpected week_start allowed"
+    except ValidationError:
+        assert True
+
+
+def test_week_start_between_1_and_7():
+    """exception should be raised for invalid `week_start`
+
+    This is non-exhaustive, but just checks the two edge cases. Only values
+    between 1 and 7 (inclusive) are valid.
+    """
+    try:
+        OnePer(period="week", week_start=0)  # type: ignore[assignment]
+        assert False, "Unexpected week_start value allowed"
+    except ValidationError:
+        assert True
+
+    try:
+        OnePer(period="week", week_start=8)  # type: ignore[assignment]
+        assert False, "Unexpected week_start value allowed"
+    except ValidationError:
+        assert True
+
+
 def check_selects_one_with_method(
     method: DetectionMethod,
-    paths: List[Path],
-    acted: List[Union[bool, int]],
+    paths: list[Path],
+    acted: list[bool | int],
 ):
     """test the OnePer::pipeline() for one set of files
 
@@ -405,7 +493,7 @@ def check_selects_one_with_method(
     :param method: How OnePer should choose "the one" file
     :type method: DetectionMethod
     :param paths: list of file Paths to process, in the order to process them
-    :type paths: List[Path]
+    :type paths: list[Path]
     :param acted: the expected results for each call of the pipeline; the call
             either return `False`, or it will return `True`, and the value of
             `res.path` will be set to a file which is specified by its index
@@ -414,15 +502,15 @@ def check_selects_one_with_method(
             `False`, the second call returns `True` with `res.path` set to
             `paths[1]`, and the third call returns `True` with `res.path` set
             to `paths[2]`
-    :type acted: List[Union[bool, int]]
+    :type acted: list[bool | int]
     """
     ## arrange
     # method, paths, expected = method_and_expect
     op = OnePer(detect_the_one_by=method)
 
     ## act
-    a: List[bool] = list()
-    r: List[Resource] = list()
+    a: list[bool] = []
+    r: list[Resource] = []
     for path in paths:
         res = Resource(path)
         act = op.pipeline(res, Output())
@@ -543,7 +631,11 @@ def test_reverses_created(may_need_real_files, acted):
         ([3, 2, 1], [2, 1, 0], [False, 1, 2], [2, 1, 0]),
     ],
 )
-def test_detects_by_first_seen(files_with_relative_ts, acted, seen):
+def test_detects_by_first_seen(
+    files_with_relative_ts: list[Path],
+    acted: list[int | bool],
+    seen: list[int],
+):
     """test `OnePer::pipeline()` with the `first seen` method
 
     This test changes the order of the paths get processed in when calling
@@ -555,7 +647,7 @@ def test_detects_by_first_seen(files_with_relative_ts, acted, seen):
     :param acted: the expected results (see `check_selects_one_with_method`)
     """
     # we want to process the files in different order
-    seen_paths: List[Path] = list()
+    seen_paths: list[Path] = []
     for i in seen:
         seen_paths.append(files_with_relative_ts[i])
 
@@ -573,7 +665,11 @@ def test_detects_by_first_seen(files_with_relative_ts, acted, seen):
         ([3, 2, 1], [2, 1, 0], [False, 0, 1], [2, 1, 0]),
     ],
 )
-def test_reverse_first_seen(files_with_relative_ts, acted, seen):
+def test_reverse_first_seen(
+    files_with_relative_ts: list[Path],
+    acted: list[bool | int],
+    seen: list[int],
+):
     """test `OnePer::pipeline()` with the `first seen` method, reversed
 
     This test changes the order of the paths get processed in when calling
@@ -585,7 +681,7 @@ def test_reverse_first_seen(files_with_relative_ts, acted, seen):
     :param acted: the expected results (see `check_selects_one_with_method`)
     """
     # we want to process the files in different order
-    seen_paths: List[Path] = list()
+    seen_paths: list[Path] = []
     for i in seen:
         seen_paths.append(files_with_relative_ts[i])
 
@@ -604,7 +700,11 @@ def test_reverse_first_seen(files_with_relative_ts, acted, seen):
         ([0, 2, 1], None, ["c", "b", "a"], [False, 0, 1]),
     ],
 )
-def test_detects_by_name(files_with_relative_ts, acted, names):
+def test_detects_by_name(
+    files_with_relative_ts: list[Path],
+    acted: list[bool | int],
+    names: list[str],
+):
     """test `OnePer::pipeline()` with the `name` method
 
     :param files_with_relative_ts: a test fixture that generates files with
@@ -617,7 +717,7 @@ def test_detects_by_name(files_with_relative_ts, acted, names):
     """
     # name the files
 
-    named_paths: List[Path] = rename_paths(
+    named_paths: list[Path] = rename_paths(
         files_with_relative_ts,
         names,
     )
@@ -637,7 +737,11 @@ def test_detects_by_name(files_with_relative_ts, acted, names):
         ([0, 1, 2], None, ["c", "b", "a"], [False, 1, 2]),
     ],
 )
-def test_reverses_name(files_with_relative_ts, acted, names):
+def test_reverses_name(
+    files_with_relative_ts: list[Path],
+    acted: list[bool | int],
+    names: list[str],
+):
     """test `OnePer::pipeline()` with the `name` method, reversed
 
     :param files_with_relative_ts: a test fixture that generates files with
@@ -650,7 +754,7 @@ def test_reverses_name(files_with_relative_ts, acted, names):
     """
     # name the files
 
-    named_paths: List[Path] = rename_paths(
+    named_paths: list[Path] = rename_paths(
         files_with_relative_ts,
         names,
     )
@@ -701,7 +805,7 @@ period_two_files = {
 }
 
 
-def test_one_period(fs):
+def test_one_period(fs: FakeFilesystem):
     """test with all files in the same period - remove all except earliest"""
     for file in sorted(period_one_files):
         make_fake_path(fs, file, period_one_files[file])
@@ -721,7 +825,7 @@ def test_one_period(fs):
             assert not Path(file).exists()
 
 
-def test_two_periods(fs):
+def test_two_periods(fs: FakeFilesystem):
     """test with two different periods - keep earliest file from each period"""
     both_periods = period_one_files | period_two_files
     for file in sorted(both_periods):
@@ -770,7 +874,7 @@ rules:
 """
 
 
-def test_with_python_and_arrow(fs):
+def test_with_python_and_arrow(fs: FakeFilesystem):
     """test with a complicated config that uses python and arrow
 
     This tests a config that restricts a time range to a portion of an hour. For
@@ -783,7 +887,7 @@ def test_with_python_and_arrow(fs):
 
     Config.from_string(CONFIG_WITH_COMPLICATED_PYTHON).execute(simulate=False)
 
-    expected: List[str] = list()
+    expected: list[str] = []
     # period_one: 00-30
     expected.append("/q")
     # period_one: 30-00

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,17 +1,24 @@
+import os
+import subprocess
+import sys
+import time
 from pathlib import Path
-from typing import Generator, List, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Union
 
 import pytest
 from arrow import Arrow
 from arrow import get as arrow_get
 from pydantic_core import ValidationError
 from pyfakefs.fake_filesystem import FakeFilesystem
+from pyfakefs.fake_filesystem_unittest import Patcher
 
 from organize import Config
 from organize.filters import OnePer
 from organize.filters.one_per import DetectionMethod, Period
 from organize.output import Default as Output
 from organize.resource import Resource
+
+FakeOrTmpFileSystem = Union[FakeFilesystem, Path]
 
 
 @pytest.fixture(params=["month", "day", "hour", "minute", "second"])
@@ -21,10 +28,11 @@ def period(request) -> Period:
 
 
 def make_fake_path(
-    fs: FakeFilesystem,
+    fs: FakeOrTmpFileSystem,
     file: str,
     mtime: Optional[Arrow] = None,
     ctime: Optional[Arrow] = None,
+    _last: bool = False,
 ) -> Path:
     """create a fake file with optional timestamps
 
@@ -40,6 +48,7 @@ def make_fake_path(
     :return: the Path to the new file
     :rtype: Path
     """
+    assert isinstance(fs, FakeFilesystem)
     fake_file = fs.create_file(file)
     path = Path(file)
     if mtime:
@@ -55,6 +64,220 @@ def make_fake_path(
         assert mts == ctime
 
     return path
+
+
+def make_tmp_path(
+    tmp_path: FakeOrTmpFileSystem,
+    file: str,
+    mtime: Optional[Arrow] = None,
+    ctime: Optional[Arrow] = None,
+    last: bool = False,
+) -> Path:
+    """Create a real file in a temporary location.
+
+    If the caller cares about the order of file creation, and this is NOT the
+    last file being created for this test case, then this function will sleep
+    for 1 second before returning, to ensure that each file has a separate
+    creation time, and that the ordering of the file creation times matches
+    what the test case expects.
+
+    :param tmp_path: a safe location for tmp files for this test execution
+    :param file: the path to the file we want to create
+    :param mtime: an optional Arrow timestamp to use for the lastmodified time
+    :param ctime: an optional Arrow timestamp to use for the file creation time;
+        it is actually impossible to change or specify this, so we mainly use
+        this to indicate that we care about the creation order
+    :param last: is this the last file for this test case, or will there be more
+    """
+    assert isinstance(tmp_path, Path)
+    tmp_file = tmp_path / file.lstrip("/")
+
+    if ctime:
+        ts = ctime.isoformat()
+        subprocess.run(["touch", "-d", ts, tmp_file], check=True)
+    else:
+        tmp_file.touch()
+    if mtime:
+        os.utime(tmp_file, (mtime.timestamp(), mtime.timestamp()))
+
+    # It is impossible to modify the file creation timestamp on real files. If
+    # a test needs to validate that files are created in a specific order, then
+    # we need to do two things:
+    # - have at least one second delay between creating each file
+    # - make sure that the "hour" is the same for each file -- this is very
+    #   specific to these tests, but since we have to delay between each file,
+    #   we want to make sure that we do not end up creating files that are
+    #   in different "hour" periods.
+    #
+    # Here, we will sleep 1 second in between each file creation. If this is the
+    # last file, we will not sleep. If no ctime was provided, we won't sleep,
+    # either, but there is currently no use case for creating real files outside
+    # of controlling the order of creation.
+    if ctime and not last:
+        time.sleep(1)
+    return tmp_file
+
+
+def make_files_with_relative_ts(
+    my_fs: Union[FakeFilesystem, Path],
+    offsets: List[int],
+    order: Optional[List[int]],
+    maker: Callable[
+        [FakeOrTmpFileSystem, str, Optional[Arrow], Optional[Arrow], bool],
+        Path,
+    ] = make_fake_path,
+) -> list[Path]:
+    """function that implements the `files_with_relative_ts` fixture.
+
+    Create all the files expected by a test case, either fake, using pyfakefs,
+    or real temporary files.
+
+    :param my_fs: either the FakeFilesystem instance, or a safe path for tmp files
+    :param offsets: an array of offsets in seconds for the timestamp for each file
+         there should always be one offset for each file desired
+    :param order: an array of offsets for the creation timestamp; these are
+         treated as seconds to add to the creation time when using pyfakefs,
+         but as the order of creation when using real tmp files; e.g., an order
+         of `[1, 0, 2]` will create `file_1` first, then `file_0`, and finally
+         `file_2` last.
+    :param maker: a function used to create the files; one version uses
+         pyfakefs, and the other version uses real tmp files
+    """
+    ctime: Optional[Arrow] = None
+    now = Arrow(2026, 7, 12, 15)
+    paths: List[Path] = list()
+    count = len(offsets)
+    for idx in range(count):
+        i = order[idx] if order else idx
+        mtime = now.shift(seconds=offsets[i])
+        if order:
+            ctime = now.shift(seconds=order[i])
+        paths.append(maker(my_fs, f"/file_{i}", mtime, ctime, (idx + 1) >= count))
+    return sorted(paths)
+
+
+@pytest.fixture
+def files_with_relative_ts(
+    fs, offsets: List[int], order: Optional[List[int]]
+) -> list[Path]:
+    """fixture to create several files with timestamps
+
+    Parameters:
+    - `offsets`: an array of offsets in seconds for the modified timestamp;
+      the value of the offset is added to the time when the function is called
+    - `order`: (optional) the order to create the files in; by default, they
+      will be created in the natural order provided by the offsets; the value of
+      order will be used as the index into the `offsets` list
+
+    Example explaining `offsets` and `order`:
+    - `offsets = [2, 0, 1]`
+    - `order = None`:
+    - Three files will be created:
+      - index 0: `/file_0` will be created with its mtime with 2 seconds
+        (from `offsets[0] = 2`)
+      - index 1: `/file_1`, mtime is +0 (`offsets[1] = 0`)
+      - index 2: `/file_2`, mtime is +1 (`offsets[2] = 1`)
+
+    Example 2:
+    - `offsets = [5, 5, 5]`
+    - `order = [2, 0, 1]`
+    - Three files will be created, in the following order:
+      - order[0] -> 2 -> offsets[2]: `/file_2`, mtime is +5
+      - order[1] -> 0 -> offsets[0]: `/file_0`, mtime is +5
+      - order[2] -> 1 -> offsets[1]: `/file_1`, mtime is +5
+    """
+    return make_files_with_relative_ts(fs, offsets, order)
+
+
+@pytest.fixture
+def may_need_real_files(
+    tmp_path,
+    offsets: list[int],
+    order: Optional[list[int]],
+) -> Generator[list[Path], None, None]:
+    """create files where we care about the creation timestamp
+
+    Create all the files expected by a test case, either fake, using pyfakefs,
+    or real temporary files.
+
+    On Windows, we can use pyfakefs, since the Windows implementation uses
+    pure python to get the file creation time.
+
+    On Linux or MacOS, we use an external command to get the file birthtime, and
+    it won't work with pyfakefs. On those OSes, we have to create real files,
+    and we have to be careful to ensure that the files have creation timestamps
+    in the order that the test case expects.
+
+    This function calls `make_files_with_relative_ts()`.
+
+    On Windows, the default behavior of `make_files_with_relative_ts()` is
+    expected.
+
+    On non-Windows systems, we first ensure that the real files will all be
+    created within the same clock hour, and then call
+    `make_files_with_relative_ts()` with the `tmp_path` value, and specify it
+    should create real files in that location.
+
+    :param tmp_path: safe location for tmp file creation, from a pytest fixture
+    :param offsets: list of modification timestamp offsets for each file; this
+        also controls how many files are created
+    :param order: optional list of creation timestamp offsets
+    """
+    if sys.platform == "win32":
+        with Patcher() as patcher:
+            # When creating pyfakefs files, we need to take care of the patching
+            # to ensure the fake filesystem gets used. This is handled
+            # automatically when using the `fs` fixture, but since we don't want
+            # to patch if we are testing on non-Windows systems, we have to
+            # do the patching manually
+            assert patcher.fs is not None
+            yield make_files_with_relative_ts(patcher.fs, offsets, order)
+    else:
+        # It is impossible to modify the file creation timestamp on real files. If
+        # a test needs to validate that files are created in a specific order, then
+        # we need to do two things:
+        # - have at least one second delay between creating each file
+        # - make sure that the "hour" is the same for each file -- this is very
+        #   specific to these tests, but since we have to delay between each file,
+        #   we want to make sure that we do not end up creating files that are
+        #   in different "hour" periods.
+        #
+        # Here, we want to make sure that we have enough time to create all the
+        # files, plus the delays between each file, and keep them all with
+        # creation times in the same hour
+        now = Arrow.now()
+        count = len(offsets)
+        later = now.shift(seconds=count)
+        if now.hour != later.hour:
+            time.sleep(count)
+        yield make_files_with_relative_ts(tmp_path, offsets, order, maker=make_tmp_path)
+
+
+def rename_paths(paths: List[Path], names: List[str]) -> List[Path]:
+    """rename a list of files to a list of new file names
+
+    :param paths: list of Paths to files that exist
+    :type paths: List[Path]
+    :param names: list of strings to be used to rename files in `paths`
+    :type names: List[str]
+
+    :return: the new list of Paths to the renamed files
+    :rtype: List[Path]
+    """
+    named_paths: List[Path] = list()
+    for i in range(len(names)):
+        named = paths[i]
+        # create a new Path that points to the new name
+        new_name = named.with_name(names[i])
+        assert not new_name.exists()
+        # rename existing file to the new_name
+        named.rename(new_name)
+        # new_name is now an existing Path, add it to list of files
+        named_paths.append(new_name)
+        assert not (named).exists()
+        assert new_name.exists()
+
+    return named_paths
 
 
 def test_tracks_seen_files(fs):
@@ -136,56 +359,6 @@ def test_tracks_file_period(fs, period):
     assert op._the_one_for_period[file_period] is f
 
 
-@pytest.fixture
-def files_with_relative_ts(
-    fs, offsets: List[int], order: Optional[List[int]]
-) -> Generator[List[Path], None, None]:
-    """fixture to create several files with timestamps
-
-    Parameters:
-    - `offsets`: an array of offsets in seconds for the modified timestamp;
-      the value of the offset is added to the time when the function is called
-    - `order`: (optional) the order to create the files in; by default, they
-      will be created in the natural order provided by the offsets; the value of
-      order will be used as the index into the `offsets` list
-
-    Example explaining `offsets` and `order`:
-    - `offsets = [2, 0, 1]`
-    - `order = None`:
-    - Three files will be created:
-      - index 0: `/file_0` will be created with its mtime with 2 seconds
-        (from `offsets[0] = 2`)
-      - index 1: `/file_1`, mtime is +0 (`offsets[1] = 0`)
-      - index 2: `/file_2`, mtime is +1 (`offsets[2] = 1`)
-
-    Example 2:
-    - `offsets = [5, 5, 5]`
-    - `order = [2, 0, 1]`
-    - Three files will be created, in the following order:
-      - order[0] -> 2 -> offsets[2]: `/file_2`, mtime is +5
-      - order[1] -> 0 -> offsets[0]: `/file_0`, mtime is +5
-      - order[2] -> 1 -> offsets[1]: `/file_1`, mtime is +5
-    """
-    ctime: Optional[Arrow] = None
-    now = Arrow(2026, 7, 12, 15)
-    paths: List[Path] = list()
-    for i in range(len(offsets)):
-        mtime = now.shift(seconds=offsets[i])
-        if order:
-            ctime = now.shift(seconds=order[i])
-        paths.append(make_fake_path(fs, f"/file_{i}", mtime, ctime))
-    yield sorted(paths)
-
-
-@pytest.fixture
-def method_and_expect(
-    files_with_relative_ts, method: DetectionMethod, expected: int
-) -> Generator[Tuple[DetectionMethod, List[Path]], None, None]:
-    """"""
-    paths = files_with_relative_ts
-    yield method, paths  # , (paths[expected])
-
-
 def check_selects_one_with_method(
     method: DetectionMethod,
     paths: List[Path],
@@ -193,9 +366,11 @@ def check_selects_one_with_method(
 ):
     """test the OnePer::pipeline() for one set of files
 
+    This performs the actual validation of `OnePer::pipeline()`.
+
     :param method: How OnePer should choose "the one" file
     :type method: DetectionMethod
-    :param paths: list of file Paths to process
+    :param paths: list of file Paths to process, in the order to process them
     :type paths: List[Path]
     :param acted: the expected results for each call of the pipeline; the call
             either return `False`, or it will return `True`, and the value of
@@ -289,7 +464,7 @@ def test_reverses_lastmodified(files_with_relative_ts, acted):
         ([5, 5, 5], [1, 0, 2], [False, 0, 2]),
     ],
 )
-def test_detects_by_created(files_with_relative_ts, acted):
+def test_detects_by_created(may_need_real_files, acted):
     """test `OnePer::pipeline()` with the `created` method
 
     This test uses different orders of file creation to alter which files
@@ -300,7 +475,7 @@ def test_detects_by_created(files_with_relative_ts, acted):
         of file creation
     :param acted: the expected results (see `check_selects_one_with_method`)
     """
-    check_selects_one_with_method("created", files_with_relative_ts, acted)
+    check_selects_one_with_method("created", may_need_real_files, acted)
 
 
 @pytest.mark.parametrize(
@@ -310,7 +485,7 @@ def test_detects_by_created(files_with_relative_ts, acted):
         ([5, 5, 5], [0, 2, 1], [False, 0, 2]),
     ],
 )
-def test_reverses_created(files_with_relative_ts, acted):
+def test_reverses_created(may_need_real_files, acted):
     """test `OnePer::pipeline()` with the `created` method, reversed
 
     This test uses different orders of file creation to alter which files
@@ -321,7 +496,7 @@ def test_reverses_created(files_with_relative_ts, acted):
         of file creation
     :param acted: the expected results (see `check_selects_one_with_method`)
     """
-    check_selects_one_with_method("-created", files_with_relative_ts, acted)
+    check_selects_one_with_method("-created", may_need_real_files, acted)
 
 
 @pytest.mark.parametrize(
@@ -381,33 +556,6 @@ def test_reverse_first_seen(files_with_relative_ts, acted, seen):
         seen_paths.append(files_with_relative_ts[i])
 
     check_selects_one_with_method("-first_seen", seen_paths, acted)
-
-
-def rename_paths(paths: List[Path], names: List[str]) -> List[Path]:
-    """rename a list of files to a list of new file names
-
-    :param paths: list of Paths to files that exist
-    :type paths: List[Path]
-    :param names: list of strings to be used to rename files in `paths`
-    :type names: List[str]
-
-    :return: the new list of Paths to the renamed files
-    :rtype: List[Path]
-    """
-    named_paths: List[Path] = list()
-    for i in range(len(names)):
-        named = paths[i]
-        # create a new Path that points to the new name
-        new_name = named.with_name(names[i])
-        assert not new_name.exists()
-        # rename existing file to the new_name
-        named.rename(new_name)
-        # new_name is now an existing Path, add it to list of files
-        named_paths.append(new_name)
-        assert not (named).exists()
-        assert new_name.exists()
-
-    return named_paths
 
 
 @pytest.mark.parametrize(

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -364,3 +364,95 @@ def test_reverse_first_seen(files_with_relative_ts, acted, seen):
         seen_paths.append(files_with_relative_ts[i])
 
     check_selects_one_with_method("-first_seen", seen_paths, acted)
+
+
+def rename_paths(paths: List[Path], names: List[str]) -> List[Path]:
+    """rename a list of files to a list of new file names
+    
+    :param paths: list of Paths to files that exist
+    :type paths: List[Path]
+    :param names: list of strings to be used to rename files in `paths`
+    :type names: List[str]
+
+    :return: the new list of Paths to the renamed files
+    :rtype: List[Path]
+    """
+    named_paths: List[Path] = list()
+    for i in range(len(names)):
+        named = paths[i]
+        # create a new Path that points to the new name
+        new_name = named.with_name(names[i])
+        assert not new_name.exists()
+        # rename existing file to the new_name
+        named.rename(new_name)
+        # new_name is now an existing Path, add it to list of files
+        named_paths.append(new_name)
+        assert not (named).exists()
+        assert new_name.exists()
+
+    return named_paths
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "names", "acted"],
+    [
+        ## "a" is expected to be the alphabetical choice of these
+        # "b" - oldest file, "c" - youngest file; seen: c, a, b
+        ([2, 1, 0], [2, 1, 0], ["c", "a", "b"], [False, 0, 2]),
+        # "c" - oldest file, "a" - youngest file; seen: a, b, c
+        ([2, 1, 0], [2, 1, 0], ["a", "b", "c"], [False, 1, 2]),
+        # "c" - oldest file, "b" - youngest file; seen: c, b, a
+        ([0, 2, 1], None, ["c", "b", "a"], [False, 0, 1]),
+    ],
+)
+def test_detects_by_name(files_with_relative_ts, acted, names):
+    """test `OnePer::pipeline()` with the `name` method
+    
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    :param names: a list of new file names; the files from 
+        `files_with_relative_ts` will be renamed to these names, so we can
+        control which files are alpabetically first or last
+    """
+    # name the files
+
+    named_paths: List[Path] = rename_paths(
+        files_with_relative_ts,
+        names,
+    )
+
+    check_selects_one_with_method("name", named_paths, acted)
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "names", "acted"],
+    [
+        ## "c" is the choice of these, in reverse alphabetical order
+        # "b" - oldest file, "c" - youngest file; seen: c, a, b
+        ([2, 1, 0], [2, 1, 0], ["c", "a", "b"], [False, 1, 2]),
+        # "c" - oldest file, "a" - youngest file; seen: a, b, c
+        ([2, 1, 0], [2, 1, 0], ["a", "b", "c"], [False, 0, 1]),
+        # "c" - oldest file, "a" - youngest file; seen: c, b, a
+        ([0, 1, 2], None, ["c", "b", "a"], [False, 1, 2]),
+    ],
+)
+def test_reverses_name(files_with_relative_ts, acted, names):
+    """test `OnePer::pipeline()` with the `name` method, reversed
+    
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    :param names: a list of new file names; the files from 
+        `files_with_relative_ts` will be renamed to these names, so we can
+        control which files are alpabetically first or last
+    """
+    # name the files
+
+    named_paths: List[Path] = rename_paths(
+        files_with_relative_ts,
+        names,
+    )
+
+    check_selects_one_with_method("-name", named_paths, acted)

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -23,7 +23,19 @@ def make_a_path(
     file: str,
     timestamp: Optional[Arrow] = None,
 ) -> Path:
-    """make sure file exists and has a specific timestamp"""
+    """make sure file exists and has a specific timestamp
+    
+    Creates a file at the specified path. If a timestamp is provided, the
+    lastmodified timestamp of the file is changed to that.
+
+    :param file: the path to the file to create
+    :type file: str
+    :param timestamp: an optional Arrow time to be used for the lastmodified
+        time of the file
+    :type timestamp: Arrow
+    :return: the Path to the new file
+    :rtype: Path
+    """
     # make sure file exists
     path = Path(file)
     path.touch()

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,11 +1,11 @@
-import os
 from pathlib import Path
-from time import sleep
 from typing import Generator, List, Optional, Tuple, Union
 
 import pytest
 from arrow import Arrow
+from arrow import get as arrow_get
 from pydantic_core import ValidationError
+from pyfakefs.fake_filesystem import FakeFilesystem
 
 from organize import Config
 from organize.filters import OnePer
@@ -20,31 +20,39 @@ def period(request) -> Period:
     return request.param
 
 
-def make_a_path(
+def make_fake_path(
+    fs: FakeFilesystem,
     file: str,
-    timestamp: Optional[Arrow] = None,
+    mtime: Optional[Arrow] = None,
+    ctime: Optional[Arrow] = None,
 ) -> Path:
-    """make sure file exists and has a specific timestamp
+    """create a fake file with optional timestamps
 
-    Creates a file at the specified path. If a timestamp is provided, the
-    lastmodified timestamp of the file is changed to that.
-
-    :param file: the path to the file to create
+    :param fs: pyfakefs FakeFilesystem (from fixture)
+    :param file: the path the the file to create
     :type file: str
-    :param timestamp: an optional Arrow time to be used for the lastmodified
+    :param mtime: optional Arrow time to use for the last modified
         time of the file
-    :type timestamp: Arrow
+    :type mtime: Arrow
+    :param ctime: optional Arrow time to use for the creation
+        time of the file
+    :type ctime: Arrow
     :return: the Path to the new file
     :rtype: Path
     """
-    # make sure file exists
+    fake_file = fs.create_file(file)
     path = Path(file)
-    path.touch()
+    if mtime:
+        fake_file.st_mtime = mtime.timestamp()
+    if ctime:
+        fake_file.st_ctime = ctime.timestamp()
 
-    # set timestamp
-    if timestamp is not None:
-        ts = timestamp.timestamp()
-        os.utime(path, (ts, ts))
+    if mtime:
+        mts = arrow_get(path.stat().st_mtime)
+        assert mts == mtime
+    if ctime:
+        mts = arrow_get(path.stat().st_ctime)
+        assert mts == ctime
 
     return path
 
@@ -54,7 +62,7 @@ def test_tracks_seen_files(fs):
     ## organize
     # create a single file
     op = OnePer()
-    a = make_a_path("/a")
+    a = make_fake_path(fs, "/a")
     r = Resource(a)
 
     ## act
@@ -72,7 +80,7 @@ def test_skips_symlinks(fs):
     ## organize
     # create a file and a symlink to it
     op = OnePer()
-    real_file = make_a_path("/real_file")
+    real_file = make_fake_path(fs, "/real_file")
     link_file = Path("/link_file")
     link_file.symlink_to(real_file)
 
@@ -112,7 +120,7 @@ def test_tracks_file_period(fs, period):
     now = Arrow(2026, 6, 26, 17, 8, 32, 123)
     # expected period for the file
     file_period = now.floor(period)
-    f = make_a_path("/f", now)
+    f = make_fake_path(fs, "/f", now)
 
     ## act
     processed = op.pipeline(Resource(f), Output())
@@ -158,21 +166,14 @@ def files_with_relative_ts(
       - order[1] -> 0 -> offsets[0]: `/file_0`, mtime is +5
       - order[2] -> 1 -> offsets[1]: `/file_1`, mtime is +5
     """
-    now = Arrow.now()
-    # try to avoid issues with file creation close to the end of the hour
-    if now.minute == 59 and now.second == 59:
-        sleep(1)
-        now = Arrow.now()
-
+    ctime: Optional[Arrow] = None
+    now = Arrow(2026, 7, 12, 15)
     paths: List[Path] = list()
     for i in range(len(offsets)):
-        idx = order[i] if order else i
-        if i > 0:
-            # force a delay between ctime stamps
-            sleep(0.01)
-        offset = offsets[idx]
-        mtime = now.shift(seconds=offset)
-        paths.append(make_a_path(f"/file_{idx}", mtime))
+        mtime = now.shift(seconds=offsets[i])
+        if order:
+            ctime = now.shift(seconds=order[i])
+        paths.append(make_fake_path(fs, f"/file_{i}", mtime, ctime))
     yield sorted(paths)
 
 
@@ -521,7 +522,7 @@ period_two_files = {
 def test_one_period(fs):
     """test with all files in the same period - remove all except earliest"""
     for file in sorted(period_one_files):
-        make_a_path(file, period_one_files[file])
+        make_fake_path(fs, file, period_one_files[file])
 
     for file in sorted(period_one_files):
         assert Path(file).exists()
@@ -542,7 +543,7 @@ def test_two_periods(fs):
     """test with two different periods - keep earliest file from each period"""
     both_periods = period_one_files | period_two_files
     for file in sorted(both_periods):
-        make_a_path(file, both_periods[file])
+        make_fake_path(fs, file, both_periods[file])
 
     Config.from_string(CONFIG_ONE_PER_DELETE).execute(simulate=False)
 
@@ -596,7 +597,7 @@ def test_with_python_and_arrow(fs):
     """
     both_periods = period_one_files | period_two_files
     for file in sorted(both_periods):
-        make_a_path(file, both_periods[file])
+        make_fake_path(fs, file, both_periods[file])
 
     Config.from_string(CONFIG_WITH_COMPLICATED_PYTHON).execute(simulate=False)
 

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -553,3 +553,67 @@ def test_two_periods(fs):
         else:
             # files other than "/q" or "/z" should not exist
             assert not Path(file).exists()
+
+
+CONFIG_WITH_COMPLICATED_PYTHON = """
+rules:
+  - name: "0"
+    locations: "."
+    filters:
+      - python: |
+          import arrow
+          ts = arrow.get(path.stat().st_mtime)
+          earliest = ts.floor("hour")
+          latest = earliest.shift(minutes=30)
+          return (ts >= earliest) and (ts < latest)
+      - one_per
+    actions:
+      - delete
+  - name: "30"
+    locations: "."
+    filters:
+      - python: |
+          import arrow
+          ts = arrow.get(path.stat().st_mtime)
+          earliest = ts.floor("hour").shift(minutes=30)
+          latest = earliest.shift(minutes=30)
+          return (ts >= earliest) and (ts < latest)
+      - one_per
+    actions:
+      - delete
+"""
+
+
+def test_with_python_and_arrow(fs):
+    """test with a complicated config that uses python and arrow
+
+    This tests a config that restricts a time range to a portion of an hour. For
+    each hour, keep the earliest file with a timestamp between 0 and 30 minutes,
+    and the earliest file with a timestamp between 30 and 60 minutes.
+    """
+    both_periods = period_one_files | period_two_files
+    for file in sorted(both_periods):
+        make_a_path(file, both_periods[file])
+
+    Config.from_string(CONFIG_WITH_COMPLICATED_PYTHON).execute(simulate=False)
+
+    expected: List[str] = list()
+    # period_one: 00-30
+    expected.append("/q")
+    # period_one: 30-00
+    expected.append("/r")
+    # period_two: 00-30
+    expected.append("/z")
+    # period_two: 30-00
+    expected.append("/v")
+
+    # "/q", "/r", "/z", and "/v" should all exist
+    for file in expected:
+        assert Path(file).exists()
+
+    for file in both_periods:
+        if file in expected:
+            assert Path(file).exists()
+        else:
+            # files other than "/q", "/r", "/z", and "/v" should not exist
+            assert not Path(file).exists()

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -17,13 +17,26 @@ def period(request) -> Period:
     return request.param
 
 
+def make_a_path(file: Path | str, timestamp: Arrow | None = None) -> Path:
+    """make sure file exists and has a specific timestamp"""
+    # make sure file exists
+    path = Path(file)
+    path.touch()
+
+    # set timestamp
+    if timestamp is not None:
+        ts = timestamp.timestamp()
+        os.utime(path, (ts, ts))
+
+    return path
+
+
 def test_tracks_seen_files(fs):
     """our filter should keep track of files that it processes"""
     ## organize
     # create a single file
     op = OnePer()
-    a = Path("/a")
-    a.touch()
+    a = make_a_path("/a")
     r = Resource(a)
 
     ## act
@@ -41,8 +54,7 @@ def test_skips_symlinks(fs):
     ## organize
     # create a file and a symlink to it
     op = OnePer()
-    real_file = Path("/real_file")
-    real_file.touch()
+    real_file = make_a_path("/real_file")
     link_file = Path("/link_file")
     link_file.symlink_to(real_file)
 
@@ -82,14 +94,7 @@ def test_tracks_file_period(fs, period):
     now = Arrow(2026, 6, 26, 17, 8, 32, 123)
     # expected period for the file
     file_period = now.floor(period)
-    # the POSIX timestamp
-    ts = now.timestamp()
-    # path to the file
-    f = Path("/f")
-    # create the file
-    f.touch()
-    # set the timestamp on the file
-    os.utime(f, (ts, ts))
+    f = make_a_path("/f", now)
 
     ## act
     processed = op.pipeline(Resource(f), Output())

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -398,7 +398,7 @@ def test_tracks_file_period(fs, period):
         now.floor(period)
         if "week" != period
         # the filter defaults to non-iso start on Sunday
-        else now.floor(period, week_start=7)
+        else now.floor(period).shift(days=-1)
     )
     f = make_fake_path(fs, "/f", now)
 
@@ -424,7 +424,8 @@ def test_week_start(fs, week_start):
     # possible time stamps
     now = Arrow(2026, 6, 26, 17, 8, 32, 123)
     # expected period for the file
-    file_period = now.floor("week", week_start=week_start)
+    shift_days = -1 if week_start == 7 else (week_start - 1)
+    file_period = now.floor("week").shift(days=shift_days)
     f = make_fake_path(fs, "/f", now)
 
     ## act

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 import time
 from pathlib import Path

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,12 +1,13 @@
 import os
 from pathlib import Path
+from typing import Generator, List, Optional, Tuple, Union
 
 import pytest
 from arrow import Arrow
 from pydantic_core import ValidationError
 
 from organize.filters import OnePer
-from organize.filters.one_per import Period
+from organize.filters.one_per import DetectionMethod, Period
 from organize.output import Default as Output
 from organize.resource import Resource
 
@@ -17,7 +18,10 @@ def period(request) -> Period:
     return request.param
 
 
-def make_a_path(file: Path | str, timestamp: Arrow | None = None) -> Path:
+def make_a_path(
+    file: str,
+    timestamp: Optional[Arrow] = None,
+) -> Path:
     """make sure file exists and has a specific timestamp"""
     # make sure file exists
     path = Path(file)
@@ -79,7 +83,7 @@ def test_valid_periods(period):
 def test_invalid_period():
     """an invalid period should raise an exception"""
     try:
-        OnePer(period="fortnight")
+        OnePer(period="fortnight")  # type: ignore[assignment]
         assert False, "Unexpected period allowed"
     except ValidationError:
         assert True
@@ -108,3 +112,104 @@ def test_tracks_file_period(fs, period):
 
     # with only one file, it should be the one for its period
     assert op._the_one_for_period[file_period] is f
+
+
+@pytest.fixture
+def files_with_relative_ts(
+    fs, offsets: List[int], order: Optional[List[int]]
+) -> Generator[List[Path], None, None]:
+    """fixture to create several files with timestamps
+
+    Parameters:
+    - `offsets`: an array of offsets in seconds for the modified timestamp;
+      the value of the offset is added to the time when the function is called
+    - `order`: (optional) the order to create the files in; by default, they
+      will be created in the natural order provided by the offsets; the value of
+      order will be used as the index into the `offsets` list
+
+    Example explaining `offsets` and `order`:
+    - `offsets = [2, 0, 1]`
+    - `order = None`:
+    - Three files will be created:
+      - index 0: `/file_0` will be created with its mtime with 2 seconds
+        (from `offsets[0] = 2`)
+      - index 1: `/file_1`, mtime is +0 (`offsets[1] = 0`)
+      - index 2: `/file_2`, mtime is +1 (`offsets[2] = 1`)
+
+    Example 2:
+    - `offsets = [5, 5, 5]`
+    - `order = [2, 0, 1]`
+    - Three files will be created, in the following order:
+      - order[0] -> 2 -> offsets[2]: `/file_2`, mtime is +5
+      - order[1] -> 0 -> offsets[0]: `/file_0`, mtime is +5
+      - order[2] -> 1 -> offsets[1]: `/file_1`, mtime is +5
+    """
+    now = Arrow.now()
+
+    paths: List[Path] = list()
+    for i in range(len(offsets)):
+        idx = order[i] if order else i
+        offset = offsets[idx]
+        mtime = now.shift(seconds=offset)
+        paths.append(make_a_path(f"/file_{idx}", mtime))
+    yield sorted(paths)
+
+
+@pytest.fixture
+def method_and_expect(
+    files_with_relative_ts, method: DetectionMethod, expected: int
+) -> Generator[Tuple[DetectionMethod, List[Path], Path], None, None]:
+    """"""
+    paths = files_with_relative_ts
+    yield method, paths, (paths[expected])
+
+
+@pytest.mark.parametrize(
+    ["method", "expected", "offsets", "order", "acted"],
+    [
+        ("lastmodified", 1, [2, 0, 1], None, [False, 0, 2]),
+        ("lastmodified", 2, [1, 2, 0], None, [False, 1, 0]),
+        ("-lastmodified", 1, [0, 2, 1], None, [False, 0, 2]),
+        ("-lastmodified", 2, [0, 1, 2], None, [False, 0, 1]),
+        ("created", 1, [5, 5, 5], [1, 0, 2], [False, 0, 2]),
+        ("-created", 1, [5, 5, 5], [0, 2, 1], [False, 0, 2]),
+    ],
+)
+def test_selects_one_with_method(method_and_expect, acted: List[Union[bool, int]]):
+    ## arrange
+    method, paths, expected = method_and_expect
+    op = OnePer(detect_the_one_by=method)
+
+    ## act
+    a: List[bool] = list()
+    r: List[Resource] = list()
+    for path in paths:
+        res = Resource(path)
+        act = op.pipeline(res, Output())
+        a.append(act)
+        r.append(res)
+
+    ## assert
+    expected_one = paths[0]
+    for i, act in enumerate(a):
+        res = r[i]
+        expected_act = acted[i]
+        expected_a = not isinstance(expected_act, bool)
+
+        # pipeline call return expected True|False
+        assert act is expected_a
+
+        # the value of res.path is correct
+        expected_res_path: Path
+        if not expected_a:
+            # value of res.path should equal the path the pipeline processed
+            expected_res_path = paths[i]
+        else:
+            # value of res.path should be updated with the previous `the_one`
+            expected_res_path = paths[expected_act]
+        assert expected_res_path == res.path
+
+        # the vars for our filter should be updated
+        if expected_act != i:
+            expected_one = paths[i]
+        assert expected_one == res.vars[op.filter_config.name]["the_one"]

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -7,6 +7,7 @@ import pytest
 from arrow import Arrow
 from pydantic_core import ValidationError
 
+from organize import Config
 from organize.filters import OnePer
 from organize.filters.one_per import DetectionMethod, Period
 from organize.output import Default as Output
@@ -24,7 +25,7 @@ def make_a_path(
     timestamp: Optional[Arrow] = None,
 ) -> Path:
     """make sure file exists and has a specific timestamp
-    
+
     Creates a file at the specified path. If a timestamp is provided, the
     lastmodified timestamp of the file is changed to that.
 
@@ -380,7 +381,7 @@ def test_reverse_first_seen(files_with_relative_ts, acted, seen):
 
 def rename_paths(paths: List[Path], names: List[str]) -> List[Path]:
     """rename a list of files to a list of new file names
-    
+
     :param paths: list of Paths to files that exist
     :type paths: List[Path]
     :param names: list of strings to be used to rename files in `paths`
@@ -419,12 +420,12 @@ def rename_paths(paths: List[Path], names: List[str]) -> List[Path]:
 )
 def test_detects_by_name(files_with_relative_ts, acted, names):
     """test `OnePer::pipeline()` with the `name` method
-    
+
     :param files_with_relative_ts: a test fixture that generates files with
         relative modification timestamps, and optionally in a specified order
         of file creation
     :param acted: the expected results (see `check_selects_one_with_method`)
-    :param names: a list of new file names; the files from 
+    :param names: a list of new file names; the files from
         `files_with_relative_ts` will be renamed to these names, so we can
         control which files are alpabetically first or last
     """
@@ -436,6 +437,7 @@ def test_detects_by_name(files_with_relative_ts, acted, names):
     )
 
     check_selects_one_with_method("name", named_paths, acted)
+
 
 @pytest.mark.parametrize(
     ["offsets", "order", "names", "acted"],
@@ -451,12 +453,12 @@ def test_detects_by_name(files_with_relative_ts, acted, names):
 )
 def test_reverses_name(files_with_relative_ts, acted, names):
     """test `OnePer::pipeline()` with the `name` method, reversed
-    
+
     :param files_with_relative_ts: a test fixture that generates files with
         relative modification timestamps, and optionally in a specified order
         of file creation
     :param acted: the expected results (see `check_selects_one_with_method`)
-    :param names: a list of new file names; the files from 
+    :param names: a list of new file names; the files from
         `files_with_relative_ts` will be renamed to these names, so we can
         control which files are alpabetically first or last
     """
@@ -468,3 +470,86 @@ def test_reverses_name(files_with_relative_ts, acted, names):
     )
 
     check_selects_one_with_method("-name", named_paths, acted)
+
+
+#####
+# tests that execute an actual Config
+
+# the config
+# this uses the default values for `one_per`:
+# - period: hour
+# - detect_the_one_by: lastmodified
+CONFIG_ONE_PER_DELETE = """
+rules:
+  - locations: "."
+    filters:
+      - one_per
+    actions:
+      - delete
+"""
+
+# files and lastmodified timestamps for the first period
+# period is 2026-July-8@15:00:00
+period_one = Arrow(2026, 7, 8, 15)
+period_one_files = {
+    # path to file: lastmodified timestamp of file
+    "/q": period_one.shift(minutes=1),
+    "/w": period_one.shift(minutes=3),
+    "/e": period_one.shift(minutes=21),
+    "/r": period_one.shift(minutes=37),
+    "/t": period_one.shift(minutes=59),
+    "/y": period_one.shift(minutes=1, seconds=1),
+}
+
+# files and lastmodified timestamps for the first period
+# period is 2026-July-8@16:00:00
+period_two = period_one.shift(hours=1)
+period_two_files = {
+    # path to file: lastmodified timestamp of file
+    "/z": period_two.shift(minutes=1),
+    "/x": period_two.shift(minutes=3),
+    "/c": period_two.shift(minutes=21),
+    "/v": period_two.shift(minutes=37),
+    "/b": period_two.shift(minutes=59),
+    "/n": period_two.shift(minutes=1, seconds=1),
+}
+
+
+def test_one_period(fs):
+    """test with all files in the same period - remove all except earliest"""
+    for file in sorted(period_one_files):
+        make_a_path(file, period_one_files[file])
+
+    for file in sorted(period_one_files):
+        assert Path(file).exists()
+
+    Config.from_string(CONFIG_ONE_PER_DELETE).execute(simulate=False)
+
+    # the earliest file in the period should exist ("/q")
+    assert Path("/q").exists()
+    for file in period_one_files:
+        if file == "/q":
+            assert Path(file).exists()
+        else:
+            # files other than "/q" should not exist
+            assert not Path(file).exists()
+
+
+def test_two_periods(fs):
+    """test with two different periods - keep earliest file from each period"""
+    both_periods = period_one_files | period_two_files
+    for file in sorted(both_periods):
+        make_a_path(file, both_periods[file])
+
+    Config.from_string(CONFIG_ONE_PER_DELETE).execute(simulate=False)
+
+    # the earliest file in period one should exist ("/q")
+    assert Path("/q").exists()
+    # the earliest file in period two should exist ("/z")
+    assert Path("/z").exists()
+    for file in both_periods:
+        if (file == "/q") or (file == "/z"):
+            assert Path(file).exists()
+        else:
+            # files other than "/q" or "/z" should not exist
+            assert not Path(file).exists()

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -91,13 +91,11 @@ def make_tmp_path(
     """
     assert isinstance(tmp_path, Path)
     tmp_file = tmp_path / file.lstrip("/")
+    tmp_file.touch()
 
     if ctime:
-        ts = ctime.isoformat()
-        subprocess.run(["touch", "-d", ts, tmp_file], check=True)
-    else:
-        tmp_file.touch()
-    if mtime:
+        os.utime(tmp_file, (ctime.timestamp(), ctime.timestamp()))
+    elif mtime:
         os.utime(tmp_file, (mtime.timestamp(), mtime.timestamp()))
 
     # It is impossible to modify the file creation timestamp on real files. If

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -169,7 +169,7 @@ def files_with_relative_ts(
         idx = order[i] if order else i
         if i > 0:
             # force a delay between ctime stamps
-            sleep(0.001)
+            sleep(0.01)
         offset = offsets[idx]
         mtime = now.shift(seconds=offset)
         paths.append(make_a_path(f"/file_{idx}", mtime))

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+
+import pytest
+from arrow import Arrow
+from pydantic_core import ValidationError
+
+from organize.filters import OnePer
+from organize.filters.one_per import Period
+from organize.output import Default as Output
+from organize.resource import Resource
+
+
+@pytest.fixture(params=["month", "day", "hour", "minute", "second"])
+def period(request) -> Period:
+    """fixture to loop over valid periods"""
+    return request.param
+
+
+def test_tracks_seen_files(fs):
+    """our filter should keep track of files that it processes"""
+    ## organize
+    # create a single file
+    op = OnePer()
+    a = Path("/a")
+    a.touch()
+    r = Resource(a)
+
+    ## act
+    processed = op.pipeline(r, Output())
+
+    ## assert
+    # with only one file handled, no files are found to process
+    assert not processed
+    # our file should be tracked
+    assert a in op._seen_files
+
+
+def test_skips_symlinks(fs):
+    """our filter should ignore symlink files"""
+    ## organize
+    # create a file and a symlink to it
+    op = OnePer()
+    real_file = Path("/real_file")
+    real_file.touch()
+    link_file = Path("/link_file")
+    link_file.symlink_to(real_file)
+
+    ## act
+    # filter our symlink
+    processed = op.pipeline(Resource(link_file), Output())
+
+    ## assert
+    # no files should be found to process
+    assert not processed
+    # the symlink should not be tracked, it should just be skipped
+    assert link_file not in op._seen_files
+
+
+def test_valid_periods(period):
+    """our filter should allow valid periods"""
+    # can we set up the filter with this period?
+    # this will raise an exception if not, and the test will fail
+    OnePer(period=period)
+
+
+def test_invalid_period():
+    """an invalid period should raise an exception"""
+    try:
+        OnePer(period="fortnight")
+        assert False, "Unexpected period allowed"
+    except ValidationError:
+        assert True
+
+
+def test_tracks_file_period(fs, period):
+    """filtering a file should track the file's period"""
+    op = OnePer(period=period)
+
+    ## organize
+    # possible time stamps
+    now = Arrow(2026, 6, 26, 17, 8, 32, 123)
+    # expected period for the file
+    file_period = now.floor(period)
+    # the POSIX timestamp
+    ts = now.timestamp()
+    # path to the file
+    f = Path("/f")
+    # create the file
+    f.touch()
+    # set the timestamp on the file
+    os.utime(f, (ts, ts))
+
+    ## act
+    processed = op.pipeline(Resource(f), Output())
+
+    ## assert
+    # one file should not find extras to process
+    assert not processed
+
+    # the period for the file should be known
+    assert file_period in op._the_one_for_period
+
+    # with only one file, it should be the one for its period
+    assert op._the_one_for_period[file_period] is f

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -167,6 +167,9 @@ def files_with_relative_ts(
     paths: List[Path] = list()
     for i in range(len(offsets)):
         idx = order[i] if order else i
+        if i > 0:
+            # force a delay between ctime stamps
+            sleep(0.001)
         offset = offsets[idx]
         mtime = now.shift(seconds=offset)
         paths.append(make_a_path(f"/file_{idx}", mtime))

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -91,11 +91,13 @@ def make_tmp_path(
     """
     assert isinstance(tmp_path, Path)
     tmp_file = tmp_path / file.lstrip("/")
-    tmp_file.touch()
 
     if ctime:
-        os.utime(tmp_file, (ctime.timestamp(), ctime.timestamp()))
-    elif mtime:
+        ts = ctime.isoformat()
+        subprocess.run(["touch", "-d", ts, tmp_file], check=True)
+    else:
+        tmp_file.touch()
+    if mtime:
         os.utime(tmp_file, (mtime.timestamp(), mtime.timestamp()))
 
     # It is impossible to modify the file creation timestamp on real files. If

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,3 +1,22 @@
+"""tests for `organize/filters/OnePer`
+
+These tests are pretty straightforward, with the exception of using the
+file creation timestamp for grouping files together.
+
+- On Windows, file creation time is obtained from the `st_ctime` attribute of a
+  file, and the pyfakefs module allows us to directly change that
+- On MacOS, file creation time is obtained from the `st_birthtime` attribute.
+  pyfakefs does not support modifying this attribute, so we need to create real
+  files. The birthtime cannot be directly manipulated, with the exception being
+  that if a timestamp on the file is set to a value *earlier* than the current
+  birthtime, the birthtime is also set to that value.
+- On Linux, it seems to be a mishmash of whether `st_birthtime` gets set or
+  not, but either way, pyfakefs isn't sufficient for our tests. There is no way
+  to change the birthtime at all, and it will allow ctime or atime to be earlier
+  than birthtime. For these tests, the only thing that seems to work is creating
+  the files in a specific order, and having a delay in between creating files.
+"""
+
 import os
 import subprocess
 import sys
@@ -93,16 +112,23 @@ def make_tmp_path(
     tmp_file = tmp_path / file.lstrip("/")
 
     if ctime:
-        ts = ctime.isoformat()
+        # On linux, gnu touch works with a variety of timestamp formats, but
+        # on MacOS, touch only accepts an ISO-like format with either 'Z', for
+        # UTC, or nothing, to use the current timezone
+        #
+        # On MacOS, if you change a timestamp to earlier than the file
+        # birthtime, it will automatically set the birthtime to the earlier
+        # time.
+        ts = ctime.isoformat()[:-6] + "Z"
         subprocess.run(["touch", "-d", ts, tmp_file], check=True)
     else:
         tmp_file.touch()
     if mtime:
         os.utime(tmp_file, (mtime.timestamp(), mtime.timestamp()))
 
-    # It is impossible to modify the file creation timestamp on real files. If
-    # a test needs to validate that files are created in a specific order, then
-    # we need to do two things:
+    # On Windows or Linux, it is impossible to modify the file creation
+    # timestamp on real files. If a test needs to validate that files are
+    # created in a specific order, then we need to do two things:
     # - have at least one second delay between creating each file
     # - make sure that the "hour" is the same for each file -- this is very
     #   specific to these tests, but since we have to delay between each file,
@@ -113,7 +139,10 @@ def make_tmp_path(
     # last file, we will not sleep. If no ctime was provided, we won't sleep,
     # either, but there is currently no use case for creating real files outside
     # of controlling the order of creation.
-    if ctime and not last:
+    #
+    # We do not need to sleep on MacOS (darwin), because we are able to
+    # manipulate the birthtime by setting the ctime.
+    if (ctime is not None) and (not last) and (sys.platform != "darwin"):
         time.sleep(1)
     return tmp_file
 
@@ -152,6 +181,11 @@ def make_files_with_relative_ts(
         mtime = now.shift(seconds=offsets[i])
         if order:
             ctime = now.shift(seconds=order[i])
+        else:
+            # if the test does not specifically change the ctime, then we will
+            # provide one anyway. This lets us enforce the correct order of file
+            # creation when testing on MacOS.
+            ctime = now.shift(hours=-1, seconds=i)
         paths.append(maker(my_fs, f"/file_{i}", mtime, ctime, (idx + 1) >= count))
     return sorted(paths)
 

--- a/tests/filters/test_oneper.py
+++ b/tests/filters/test_oneper.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from time import sleep
 from typing import Generator, List, Optional, Tuple, Union
 
 import pytest
@@ -145,6 +146,10 @@ def files_with_relative_ts(
       - order[2] -> 1 -> offsets[1]: `/file_1`, mtime is +5
     """
     now = Arrow.now()
+    # try to avoid issues with file creation close to the end of the hour
+    if now.minute == 59 and now.second == 59:
+        sleep(1)
+        now = Arrow.now()
 
     paths: List[Path] = list()
     for i in range(len(offsets)):
@@ -158,26 +163,35 @@ def files_with_relative_ts(
 @pytest.fixture
 def method_and_expect(
     files_with_relative_ts, method: DetectionMethod, expected: int
-) -> Generator[Tuple[DetectionMethod, List[Path], Path], None, None]:
+) -> Generator[Tuple[DetectionMethod, List[Path]], None, None]:
     """"""
     paths = files_with_relative_ts
-    yield method, paths, (paths[expected])
+    yield method, paths  # , (paths[expected])
 
 
-@pytest.mark.parametrize(
-    ["method", "expected", "offsets", "order", "acted"],
-    [
-        ("lastmodified", 1, [2, 0, 1], None, [False, 0, 2]),
-        ("lastmodified", 2, [1, 2, 0], None, [False, 1, 0]),
-        ("-lastmodified", 1, [0, 2, 1], None, [False, 0, 2]),
-        ("-lastmodified", 2, [0, 1, 2], None, [False, 0, 1]),
-        ("created", 1, [5, 5, 5], [1, 0, 2], [False, 0, 2]),
-        ("-created", 1, [5, 5, 5], [0, 2, 1], [False, 0, 2]),
-    ],
-)
-def test_selects_one_with_method(method_and_expect, acted: List[Union[bool, int]]):
+def check_selects_one_with_method(
+    method: DetectionMethod,
+    paths: List[Path],
+    acted: List[Union[bool, int]],
+):
+    """test the OnePer::pipeline() for one set of files
+
+    :param method: How OnePer should choose "the one" file
+    :type method: DetectionMethod
+    :param paths: list of file Paths to process
+    :type paths: List[Path]
+    :param acted: the expected results for each call of the pipeline; the call
+            either return `False`, or it will return `True`, and the value of
+            `res.path` will be set to a file which is specified by its index
+            in the `paths` param;
+            e.g., `acted=[False, 1, 2]` indicates: the first call returns
+            `False`, the second call returns `True` with `res.path` set to
+            `paths[1]`, and the third call returns `True` with `res.path` set
+            to `paths[2]`
+    :type acted: List[Union[bool, int]]
+    """
     ## arrange
-    method, paths, expected = method_and_expect
+    # method, paths, expected = method_and_expect
     op = OnePer(detect_the_one_by=method)
 
     ## act
@@ -213,3 +227,140 @@ def test_selects_one_with_method(method_and_expect, acted: List[Union[bool, int]
         if expected_act != i:
             expected_one = paths[i]
         assert expected_one == res.vars[op.filter_config.name]["the_one"]
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "acted"],
+    [
+        ([2, 0, 1], None, [False, 0, 2]),
+        ([1, 2, 0], None, [False, 1, 0]),
+    ],
+)
+def test_detects_by_lastmodified(files_with_relative_ts, acted):
+    """test `OnePer::pipeline()` with the `lastmodified` method
+
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    """
+    check_selects_one_with_method("lastmodified", files_with_relative_ts, acted)
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "acted"],
+    [
+        ([0, 2, 1], None, [False, 0, 2]),
+        ([0, 1, 2], None, [False, 0, 1]),
+    ],
+)
+def test_reverses_lastmodified(files_with_relative_ts, acted):
+    """test `OnePer::pipeline()` with the `lastmodified` method, reversed
+
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    """
+    check_selects_one_with_method("-lastmodified", files_with_relative_ts, acted)
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "acted"],
+    [
+        ([3, 2, 1], None, [False, 1, 2]),
+        ([5, 5, 5], [1, 0, 2], [False, 0, 2]),
+    ],
+)
+def test_detects_by_created(files_with_relative_ts, acted):
+    """test `OnePer::pipeline()` with the `created` method
+
+    This test uses different orders of file creation to alter which files
+    are filtered.
+
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    """
+    check_selects_one_with_method("created", files_with_relative_ts, acted)
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "acted"],
+    [
+        ([1, 2, 3], None, [False, 0, 1]),
+        ([5, 5, 5], [0, 2, 1], [False, 0, 2]),
+    ],
+)
+def test_reverses_created(files_with_relative_ts, acted):
+    """test `OnePer::pipeline()` with the `created` method, reversed
+
+    This test uses different orders of file creation to alter which files
+    are filtered.
+
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    """
+    check_selects_one_with_method("-created", files_with_relative_ts, acted)
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "acted", "seen"],
+    [
+        # The file indexes for `acted` are based on the `seen` order,
+        # not `order` or `offsets`
+        ([1, 2, 3], None, [False, 1, 2], [2, 1, 0]),
+        ([1, 2, 3], None, [False, 1, 2], [1, 0, 2]),
+        ([3, 2, 1], [2, 1, 0], [False, 1, 2], [2, 1, 0]),
+    ],
+)
+def test_detects_by_first_seen(files_with_relative_ts, acted, seen):
+    """test `OnePer::pipeline()` with the `first seen` method
+
+    This test changes the order of the paths get processed in when calling
+    the pipeline.
+
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    """
+    # we want to process the files in different order
+    seen_paths: List[Path] = list()
+    for i in seen:
+        seen_paths.append(files_with_relative_ts[i])
+
+    check_selects_one_with_method("first_seen", seen_paths, acted)
+
+
+@pytest.mark.parametrize(
+    ["offsets", "order", "acted", "seen"],
+    [
+        # The file indexes for `acted` are based on the `seen` order,
+        # not `order` or `offsets`
+        ([3, 2, 1], None, [False, 0, 1], [2, 1, 0]),
+        ([3, 2, 1], None, [False, 0, 1], [1, 0, 2]),
+        ([3, 2, 1], [2, 1, 0], [False, 0, 1], [0, 1, 2]),
+        ([3, 2, 1], [2, 1, 0], [False, 0, 1], [2, 1, 0]),
+    ],
+)
+def test_reverse_first_seen(files_with_relative_ts, acted, seen):
+    """test `OnePer::pipeline()` with the `first seen` method, reversed
+
+    This test changes the order of the paths get processed in when calling
+    the pipeline.
+
+    :param files_with_relative_ts: a test fixture that generates files with
+        relative modification timestamps, and optionally in a specified order
+        of file creation
+    :param acted: the expected results (see `check_selects_one_with_method`)
+    """
+    # we want to process the files in different order
+    seen_paths: List[Path] = list()
+    for i in seen:
+        seen_paths.append(files_with_relative_ts[i])
+
+    check_selects_one_with_method("-first_seen", seen_paths, acted)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

### New Filter: `one_per`

This adds a new filter: `one_per`.

**OnePer** is a filter that groups files by time period and selectively emits files based on a detection method. For each time period, it identifies one "canonical" file (the earliest, newest, first-seen, etc.) and returns `True` only for the "extra" files in that period. The canonical file for each period is available via `{one_per.the_one}` but is not emitted. This enables deduplication workflows like removing redundant backups while keeping one representative file per period.

**In simpler terms:** It keeps one file per time period and marks all others as candidates for deletion/processing.

The periods used for grouping can be:
  - month
  - day
  - hour
  - minute
  - second

The method for choosing the one file can be:
  - lastmodified -- the modified timestamp
  - created -- the file creation timestamp
  - name
  - first_seen

The sort order can be reversed by prefixing "-"; e.g., "-lastmodified", "-name".

### Updates to Workflow Actions

All workflow actions have been updated to the current versions.
- `actions/checkout@v7.0.0`
- `docker/login-action@v4.4.0`
- `docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302` (`v6.2.0`)
- `docker/build-push-action@v7.3.0`
- `actions/setup-python@v6.3.0`
- `astral-sh/setup-uv@v8.3.2`

## Related issue number

There are no related issues, this is a new feature.

## Checklist

- [x] Tests for the changes exist and pass on CI
- [x] Documentation reflects the changes where applicable
- [x] Change is documented in CHANGELOG.md (if applicable)
- [x] My PR is ready to review
